### PR TITLE
feat: DTOSS-4810 Add optional RBAC role assignment to Key Vault module

### DIFF
--- a/infrastructure/modules/function-app/rbac.tf
+++ b/infrastructure/modules/function-app/rbac.tf
@@ -1,6 +1,6 @@
 module "rbac_assignmnents" {
+  # This results in a numbered index, necessary to avoid keying on values that are only known after apply (scope is a resource id)
   for_each = { for idx, assignment in var.rbac_role_assignments : idx => assignment }
-
 
   source = "../rbac-assignment"
 

--- a/infrastructure/modules/key-vault/rbac.tf
+++ b/infrastructure/modules/key-vault/rbac.tf
@@ -1,0 +1,10 @@
+# Need to give the deployment service principal the required permissions to the key vault
+module "rbac_assignmnents" {
+  for_each = var.enable_rbac_authorization ? toset(var.rbac_roles) : []
+
+  source = "../rbac-assignment"
+
+  principal_id         = data.azurerm_client_config.current.object_id
+  role_definition_name = each.key
+  scope                = azurerm_key_vault.keyvault.id
+}

--- a/infrastructure/modules/key-vault/variables.tf
+++ b/infrastructure/modules/key-vault/variables.tf
@@ -46,6 +46,12 @@ variable "purge_protection_enabled" {
   default     = false
 }
 
+variable "rbac_roles" {
+  description = "List of RBAC roles to assign to the Key Vault."
+  type        = list(string)
+  default     = []
+}
+
 variable "soft_delete_retention" {
   type        = number
   description = "Name of the  Key Vault which is created."

--- a/infrastructure/modules/storage/rbac.tf
+++ b/infrastructure/modules/storage/rbac.tf
@@ -1,11 +1,11 @@
-# Need to give the depolyment service principal the required permissions to the storage account
+# Need to give the deployment service principal the required permissions to the storage account
 module "rbac_assignmnents" {
-  for_each = { for idx, assignment in var.rbac_roles : idx => assignment }
+  for_each = toset(var.rbac_roles)
 
   source = "../rbac-assignment"
 
   principal_id         = data.azurerm_client_config.current.object_id
-  role_definition_name = each.value
+  role_definition_name = each.key
   scope                = azurerm_storage_account.storage_account.id
 }
 

--- a/infrastructure/modules/storage/variables.tf
+++ b/infrastructure/modules/storage/variables.tf
@@ -63,9 +63,9 @@ variable "public_network_access_enabled" {
 }
 
 variable "rbac_roles" {
-  description = "Map of RBAC roles to assign to the Storage Account."
-  type        = map(string)
-  default     = {}
+  description = "List of RBAC roles to assign to the Storage Account."
+  type        = list(string)
+  default     = []
 }
 
 variable "tags" {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

The Key Vault module now optionally accepts a list of RBAC roles to assign to the Terraform Managed Identity - ensuring that it will be able to reference items stored within it in future.

This change also brings a simplification to the Storage module's RBAC roles input variable, so a fix needs applying to the other projects using it:
- Cohort Manager (tested in a branch [here](https://dev.azure.com/nhse-dtos/dtos-cohort-manager/_build/results?buildId=7554&view=logs&j=ced2749f-787a-529b-d064-72b5c61df22f&t=a8ef944f-7917-542a-f805-14b39eb0c11c) successful plan, changes to diagnostic settings are unrelated, from test deployments from another branch)
- Service Insights (change added to the work-in-progress branch)
- Communication Management (already implemented)


## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
