### PR TITLE
fix: module name spelling in calls to subordinate RBAC Assignment module

### DIFF
--- a/infrastructure/modules/function-app/rbac.tf
+++ b/infrastructure/modules/function-app/rbac.tf
@@ -1,4 +1,4 @@
-module "rbac_assignmnents" {
+module "rbac_assignments" {
   # This results in a numbered index, necessary to avoid keying on values that are only known after apply (scope is a resource id)
   for_each = { for idx, assignment in var.rbac_role_assignments : idx => assignment }
 

--- a/infrastructure/modules/key-vault/rbac.tf
+++ b/infrastructure/modules/key-vault/rbac.tf
@@ -1,5 +1,5 @@
 # Need to give the deployment service principal the required permissions to the key vault
-module "rbac_assignmnents" {
+module "rbac_assignments" {
   for_each = var.enable_rbac_authorization ? toset(var.rbac_roles) : []
 
   source = "../rbac-assignment"

--- a/infrastructure/modules/sql-server/rbac.tf
+++ b/infrastructure/modules/sql-server/rbac.tf
@@ -1,5 +1,5 @@
 # Need to give the depolyment service principal the required permissions to the storage account
-module "rbac_assignmnents" {
+module "rbac_assignments" {
   for_each = { for idx, role in local.rbac_roles : idx => role }
 
   source = "../rbac-assignment"

--- a/infrastructure/modules/storage/rbac.tf
+++ b/infrastructure/modules/storage/rbac.tf
@@ -1,5 +1,5 @@
 # Need to give the deployment service principal the required permissions to the storage account
-module "rbac_assignmnents" {
+module "rbac_assignments" {
   for_each = toset(var.rbac_roles)
 
   source = "../rbac-assignment"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fix for naming typo in references to subordinate RBAC Assignment module. These names are not referenced in any of the three project codebases. This misspelled name was only used by modules which call the RBAC module. The impact of the change will be that the RBAC assignments will be re-created when projects are re-deployed with this new version of the Terraform module templates.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
