### PR TITLE
fix: DTOS 5205 apply metrics fix to avoid recreation of resources

### DIFF
--- a/infrastructure/modules/diagnostic-settings/main.tf
+++ b/infrastructure/modules/diagnostic-settings/main.tf
@@ -18,6 +18,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     for_each = var.metric
     content {
       category = metric.value
+      enabled  = var.metric_enabled
     }
   }
 

--- a/infrastructure/modules/diagnostic-settings/variables.tf
+++ b/infrastructure/modules/diagnostic-settings/variables.tf
@@ -33,6 +33,12 @@ variable "metric" {
   default     = []
 }
 
+variable "metric_enabled" {
+  type        = bool
+  description = "to enable retention for diagnostic settings metric"
+  default     = true
+}
+
 variable "storage_account_id" {
   type        = string
   description = "value of the storage account id if logging to storage account is being used."

--- a/infrastructure/modules/key-vault/main.tf
+++ b/infrastructure/modules/key-vault/main.tf
@@ -62,6 +62,6 @@ module "diagnostic-settings" {
   log_analytics_workspace_id = var.log_analytics_workspace_id
   enabled_log                = var.monitor_diagnostic_setting_keyvault_enabled_logs
   metric                     = var.monitor_diagnostic_setting_keyvault_metrics
-
+  metric_enabled             = var.metric_enabled
 }
 

--- a/infrastructure/modules/key-vault/variables.tf
+++ b/infrastructure/modules/key-vault/variables.tf
@@ -19,6 +19,12 @@ variable "log_analytics_workspace_id" {
   description = "id of the log analytics workspace to send resource logging to via diagnostic settings"
 }
 
+variable "metric_enabled" {
+  type        = bool
+  description = "to enable retention for diagnostic settings metric"
+  default     = true
+}
+
 variable "monitor_diagnostic_setting_keyvault_enabled_logs" {
   type        = list(string)
   description = "Controls what logs will be enabled for the keyvault"

--- a/infrastructure/modules/log-analytics-workspace/main.tf
+++ b/infrastructure/modules/log-analytics-workspace/main.tf
@@ -15,8 +15,8 @@ resource "azurerm_log_analytics_workspace" "log_analytics_workspace" {
 module "diagnostic-settings" {
   source = "../diagnostic-settings"
 
-  name                       = "${var.name}-diagnostic-setting"
-  target_resource_id         = azurerm_log_analytics_workspace.log_analytics_workspace.id
+  name               = "${var.name}-diagnostic-setting"
+  target_resource_id = azurerm_log_analytics_workspace.log_analytics_workspace.id
 
   log_analytics_workspace_id = azurerm_log_analytics_workspace.log_analytics_workspace.id
   enabled_log                = var.monitor_diagnostic_setting_log_analytics_workspace_enabled_logs

--- a/infrastructure/modules/postgresql-flexible/main.tf
+++ b/infrastructure/modules/postgresql-flexible/main.tf
@@ -43,12 +43,12 @@ resource "azurerm_postgresql_flexible_server_active_directory_administrator" "po
 
 # Create the server configurations
 resource "azurerm_postgresql_flexible_server_configuration" "postgresql_flexible_config" {
-  for_each  = var.postgresql_configurations
+  for_each = var.postgresql_configurations
 
   server_id = azurerm_postgresql_flexible_server.postgresql_flexible_server.id
 
-  name      = each.key
-  value     = each.value
+  name  = each.key
+  value = each.value
 }
 
 /* --------------------------------------------------------------------------------------------------

--- a/infrastructure/modules/shared-config/output.tf
+++ b/infrastructure/modules/shared-config/output.tf
@@ -26,7 +26,7 @@ locals {
         apim_portal  = lower("apim-portal-beap-${var.env}-${var.location_map[var.location]}-${var.application}")
       }
       backend_http_settings_name = {
-        apim_shared = lower("apim-shared-htst-${var.env}-${var.location_map[var.location]}-${var.application}")
+        apim_shared  = lower("apim-shared-htst-${var.env}-${var.location_map[var.location]}-${var.application}")
         apim_gateway = lower("apim-gateway-htst-${var.env}-${var.location_map[var.location]}-${var.application}")
         apim_portal  = lower("apim-portal-htst-${var.env}-${var.location_map[var.location]}-${var.application}")
       }

--- a/infrastructure/modules/storage/main.tf
+++ b/infrastructure/modules/storage/main.tf
@@ -86,6 +86,6 @@ module "diagnostic-settings" {
   target_resource_id         = "${azurerm_storage_account.storage_account.id}/${each.value}/default"
   log_analytics_workspace_id = var.log_analytics_workspace_id
   enabled_log                = var.monitor_diagnostic_setting_storage_account_enabled_logs
-  metric                     = ["AllMetrics"]
+  metric                     = var.monitor_diagnostic_setting_storage_account_metrics
 
 }

--- a/infrastructure/modules/storage/variables.tf
+++ b/infrastructure/modules/storage/variables.tf
@@ -49,6 +49,11 @@ variable "monitor_diagnostic_setting_storage_account_enabled_logs" {
   description = "Controls what logs will be enabled for the storage"
 }
 
+variable "monitor_diagnostic_setting_storage_account_metrics" {
+  type        = list(string)
+  description = "Controls what metrics will be enabled for the storage"
+}
+
 variable "private_endpoint_properties" {
   description = "Consolidated properties for the Function App Private Endpoint."
   type = object({


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

Fix to prevent recreation of resources by hard-coding the metrics category. 

infrastructure/modules/diagnostic-settings/main.tf:
New variable required: var.metric_enabled

infrastructure/modules/log-analytics-workspace/main.tf:
Reference to azurerm_log_analytics_workspace.log_analytics_workspace.id now required within the module resource. Please use the expression:
target_resource_id = azurerm_log_analytics_workspace.log_analytics_workspace.id

infrastructure/modules/storage/main.tf:
New variable required called: var.monitor_diagnostic_setting_storage_account_metrics

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
