### PR TITLE
fix: Better matching of shared code folder name in CI image build

### DIFF
--- a/.github/workflows/stage-3-build-images.yaml
+++ b/.github/workflows/stage-3-build-images.yaml
@@ -11,6 +11,7 @@ on:
         description: Environment of the deployment
         required: true
         type: string
+        default: development
       docker_compose_file:
         description: The path of the compose.yaml file needed to build docker images
         required: true
@@ -127,7 +128,7 @@ jobs:
           echo "Commit hash tag: ${SHORT_COMMIT_HASH}"
           echo "COMMIT_HASH_TAG=${SHORT_COMMIT_HASH}" >> ${GITHUB_ENV}
 
-          echo "ENVIRONMENT_TAG=development" >> ${GITHUB_ENV}
+          echo "ENVIRONMENT_TAG=${{ inputs.environment_tag }}" >> ${GITHUB_ENV}
 
       - name: Build and Push Image
         working-directory: ${{ steps.get-function-names.outputs.DOCKER_COMPOSE_DIR }}

--- a/scripts/deployments/get-docker-names.sh
+++ b/scripts/deployments/get-docker-names.sh
@@ -34,7 +34,7 @@ changed_functions=""
 if [ -z "$CHANGED_FOLDERS" ]; then
     changed_functions="null"
     echo "No files changed"
-elif [[ "$CHANGED_FOLDERS" == *Shared* ]]; then
+elif [[ "$CHANGED_FOLDERS" =~ (?i)Shared ]]; then
     echo "Shared folder changed, returning all functions"
     for key in "${!docker_functions_map[@]}"; do
         changed_functions+=" ${docker_functions_map[$key]}"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Account for variability in shared code folder name (now case insensitive)
- Parameterise the Docker image tag (defaults to `development`, but can now be specified)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
