### PR TITLE
fix: ACR module, block public network access is no longer ignored

### DIFF
--- a/infrastructure/modules/container-registry/main.tf
+++ b/infrastructure/modules/container-registry/main.tf
@@ -1,10 +1,12 @@
 
 resource "azurerm_container_registry" "acr" {
-  name                = var.name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  sku                 = var.sku
-  admin_enabled       = var.admin_enabled
+  name                          = var.name
+  location                      = var.location
+  resource_group_name           = var.resource_group_name
+  sku                           = var.sku
+  admin_enabled                 = var.admin_enabled
+  public_network_access_enabled = var.public_network_access_enabled
+  zone_redundancy_enabled       = var.zone_redundancy_enabled
 
   identity {
     type         = "UserAssigned"

--- a/infrastructure/modules/container-registry/variables.tf
+++ b/infrastructure/modules/container-registry/variables.tf
@@ -37,7 +37,7 @@ variable "private_endpoint_properties" {
 
 variable "public_network_access_enabled" {
   type        = bool
-  description = "Controls whether data in the account may be accessed from public networks."
+  description = "Controls whether the acr may be accessed from public networks."
   default     = false
 }
 
@@ -55,4 +55,9 @@ variable "tags" {
   type        = map(string)
   description = "Resource tags to be applied throughout the deployment."
   default     = {}
+}
+
+variable "zone_redundancy_enabled" {
+  type    = bool
+  default = false
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Although a variable existed to control public network access to ACR, it was not being used. Therefore until now all ACRs deployed were publicly accessible (the default behaviour), and would keep being made public each time the Terraform state was deployed.

Also added zone redundancy option (which unfortunately means this is disabled on all ACRs deployed to date). To remediate this requires a replacement of each ACR, so it's best tackled asap.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
