### PR TITLE
feat: ACR image import and re-tag pipeline template, inc. Prod

### DIFF
--- a/.azuredevops/templates/steps/acr-import-retag.yaml
+++ b/.azuredevops/templates/steps/acr-import-retag.yaml
@@ -1,0 +1,68 @@
+---
+
+parameters:
+  - name: serviceConnection
+    type: string
+
+steps:
+  - checkout: none
+  - task: AzureCLI@2
+    name: publish_images
+    displayName: Publish $(SELECT_IMAGE_TAG) images to $(ADD_IMAGE_TAG)
+    inputs:
+      azureSubscription: ${{ parameters.serviceConnection }}
+      addSpnToEnvironment: true
+      failOnStandardError: false
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        # Prerequisite: A DNS A record for the chosen Dev ACR must exist in the Prod privatelink.azurecr.io zone, resolving to the public IP for that ACR
+        set -eo pipefail
+        declare -a pids
+
+        wait_for_completion() {
+          # acr tasks are backgrounded for parallelism
+          local -n arr=$1
+          for pid in "${arr[@]}"; do
+            wait ${pid}
+          done
+        }
+
+        echo "##[debug] Authenticating with container registry ${SRC_REGISTRY}..."
+        az acr login --name ${SRC_REGISTRY}
+        # az acr check-health --name ${SRC_REGISTRY} --yes
+
+        if [[ "${SRC_REGISTRY}" == ${DEST_REGISTRY} ]]; then
+          src_reg_prefix="${SRC_REGISTRY}.azurecr.io/" # omitted when the source registry is in a different subscription
+        else
+          [[ "${SRC_REGISTRY}" =~ dev ]] && cmdopt_sub="--subscription ${TF_VAR_HUB_SUBSCRIPTION_ID}"
+          source_registry_id=$(az acr show --name ${SRC_REGISTRY} ${cmdopt_sub} --query id --output tsv)
+          cmdopt_reg="--registry ${source_registry_id}" # needed when the source registry is in a different subscription
+          echo "##[debug] Authenticating with container registry ${DEST_REGISTRY}..."
+          az acr login --name ${DEST_REGISTRY}
+          # az acr check-health --name ${DEST_REGISTRY} --yes
+        fi
+
+        [[ "${DEST_REGISTRY}" =~ dev ]] && az account set -s ${TF_VAR_HUB_SUBSCRIPTION_ID}
+        repos=$(az acr repository list --name ${SRC_REGISTRY} --output tsv)
+
+        for repo in ${repos}; do
+          echo "##[debug] Importing ${repo}:${SELECT_IMAGE_TAG}..."
+          az acr import --name ${DEST_REGISTRY} --source ${src_reg_prefix}${repo}:${SELECT_IMAGE_TAG} --image ${repo}:${ADD_IMAGE_TAG} ${cmdopt_reg} --force &
+          pids+=($!)
+        done
+        wait_for_completion pids
+
+        if [[ "${SRC_REGISTRY}" != "${DEST_REGISTRY}" ]]; then
+          # To minimise data transfers, use only the destination acr to add other relevant tags taken from the source registry (PR ref, commit hash)
+          pids=()
+          for repo in ${repos}; do
+            image_sha=$(az acr repository show --name ${SRC_REGISTRY} --image ${repo}:${SELECT_IMAGE_TAG} --query digest --output tsv)
+            for tag in $(az acr repository show --name ${SRC_REGISTRY} --image ${repo}@${image_sha} --query "tags" --output tsv | grep -E '^(pr[0-9]+|[a-f0-9]{7})$'); do
+              echo "##[debug] Adding tag ${repo}:${tag}..."
+              az acr import --name ${DEST_REGISTRY} --source ${DEST_REGISTRY}.azurecr.io/${repo}:${ADD_IMAGE_TAG} --image ${repo}:${tag} --force &
+              pids+=($!)
+            done
+          done
+          wait_for_completion pids
+        fi


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

ACR image copying and re-tagging pipeline suitable for re-use by all projects. It can retag images in either Dev or Prod project ACRs, and migrate images between them. It preserves the PR and commit ref tags when migrating images.

One significant improvement here is the parallelism of the `az acr` jobs, which should result in a rapid pipeline execution, even for projects which have many Docker images. Furthermore there is no need for artifact storage nor multiple pipeline stages.

This script has a pre-requisite of a DNS A record for the Dev ACR existing in the Prod Hub `privatelink.azurecr.io` domain which must resolve to the public IP of the Dev ACR.

Example run, in Communication Management project:
https://dev.azure.com/nhse-dtos/dtos-communication-management/_build/results?buildId=10156&view=results

## Context

Previously, Docker image promotion into Prod environments was only possible via VM with Docker installed - by downloading, re-tagging, and uploading each image.

This new approach achieves the same result but uses the destination ACR to pull and re-tag the images itself, and using parallelism to optimise run duration.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
