### PR TITLE
Feat: Amend virtual-desktop module to support Azure Compute Gallery OS images

### DIFF
--- a/infrastructure/modules/virtual-desktop/variables.tf
+++ b/infrastructure/modules/virtual-desktop/variables.tf
@@ -70,20 +70,23 @@ variable "maximum_sessions_allowed" {
   default = 16
 }
 
-variable "source_image_offer" {
-  type = string
+variable "source_image_from_gallery" {
+  type = object({
+    image_name      = string
+    gallery_name    = string
+    gallery_rg_name = string
+  })
+  default = null
 }
 
-variable "source_image_publisher" {
-  type = string
-}
-
-variable "source_image_sku" {
-  type = string
-}
-
-variable "source_image_version" {
-  type = string
+variable "source_image_reference" {
+  type = object({
+    offer     = string
+    publisher = string
+    sku       = string
+    version   = string
+  })
+  default = null
 }
 
 variable "subnet_id" {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Allows virtual desktop session hosts to be built with either `source_image_reference` as before (for stock Azure OS images), or with `source_image_id`. The module code expects the relevant parameters to be defined in either of the two variable objects:

- `source_image_reference` or
- `source_image_from_gallery`

## Context

This allows the virtual desktops to be built from a golden image complete with the required application software, which will need to be updated.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
