### PR TITLE
feat: dtoss 6910 enabling health checks for function apps

### DIFF
--- a/infrastructure/modules/event-grid-subscription/main.tf
+++ b/infrastructure/modules/event-grid-subscription/main.tf
@@ -1,6 +1,6 @@
 resource "azurerm_eventgrid_event_subscription" "eventgrid_event_subscription" {
-  name     = var.subscription_name
-  scope    = var.azurerm_eventgrid_id
+  name  = var.subscription_name
+  scope = var.azurerm_eventgrid_id
 
   dynamic "azure_function_endpoint" {
     for_each = var.subscriber_function_details

--- a/infrastructure/modules/function-app/main.tf
+++ b/infrastructure/modules/function-app/main.tf
@@ -31,6 +31,7 @@ resource "azurerm_linux_function_app" "function_app" {
     container_registry_use_managed_identity       = var.cont_registry_use_mi
     container_registry_managed_identity_client_id = var.acr_mi_client_id
     ftps_state                                    = var.ftps_state
+    health_check_path                             = var.health_check_path
 
     minimum_tls_version = var.minimum_tls_version
 

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -72,6 +72,11 @@ variable "function_app_slots" {
   default = []
 }
 
+variable "health_check_path" {
+  type        = string
+  description = "When configured will enable health checking. Setting example= /api/health"
+  default     = ""
+
 variable "http_version" {
   type        = string
   description = "The HTTP version to use for the function app. Override standard default."

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -76,6 +76,7 @@ variable "health_check_path" {
   type        = string
   description = "When configured will enable health checking. Setting example= /api/health"
   default     = ""
+}
 
 variable "http_version" {
   type        = string


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

Code change to enabling health checks for function apps when a Health probe path is added to the tfvars

<!-- Why is this change required? What problem does it solve? -->

https://dev.azure.com/nhse-dtos/dtos-cohort-manager/_build/results?buildId=13649&view=logs&j=c970d263-77bb-52d7-1861-5b2637d7126d&t=c970d263-77bb-52d7-1861-5b2637d7126d

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
