### PR TITLE
fix: Bug in checkout comparison logic

### DIFF
--- a/.github/workflows/stage-3-build-images.yaml
+++ b/.github/workflows/stage-3-build-images.yaml
@@ -38,6 +38,9 @@ jobs:
       FUNC_NAMES: ${{ steps.get-function-names.outputs.FUNC_NAMES }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # to allow git diff between HEAD and the previous commit to main branch
+          fetch-depth: 2
 
       - name: Checkout dtos-devops-templates repository
         uses: actions/checkout@v4
@@ -45,8 +48,6 @@ jobs:
           repository: NHSDigital/dtos-devops-templates
           path: templates
           ref: main
-          # to allow git diff between HEAD and the previous commit to main branch
-          fetch-depth: 2
 
       - name: Determine which Docker container(s) to build
         id: get-function-names


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

```
with:
  fetch-depth: 2
```

The above additional parameter for the Git checkout was applied to the wrong repo (the templates repo, and not to the default repo checkout). Consequently the Docker container builds after merging a PR were failing from the 17th March when compromised GitHub Action `tj-actions/changed-files` was remove, until now.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
