### PR TITLE
fix: DTOSS-7964 VM tagging for Azure Policy requirement

### DIFF
--- a/infrastructure/modules/virtual-desktop/session-host.tf
+++ b/infrastructure/modules/virtual-desktop/session-host.tf
@@ -72,7 +72,12 @@ resource "azurerm_windows_virtual_machine" "this" {
     enabled = true
   }
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      EnablePrivateNetworkGC = "TRUE" # mandated by Azure Policy
+    }
+  )
 
   lifecycle {
     ignore_changes = [vm_agent_platform_updates_enabled]


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Azure Policy requires VMs to have a specific tag for some reason, otherwise their creation is denied.

## Testing

Deployed to Dev Hub:
https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=16440&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
