### PR TITLE
feat: DTOSS-7970 Allow specifying the AVD OS source_image_id directly

### DIFF
--- a/infrastructure/modules/virtual-desktop/session-host.tf
+++ b/infrastructure/modules/virtual-desktop/session-host.tf
@@ -66,7 +66,9 @@ resource "azurerm_windows_virtual_machine" "this" {
     }
   }
 
-  source_image_id = var.source_image_from_gallery != null && var.source_image_reference == null ? data.azurerm_shared_image.gallery_image[0].id : null
+  source_image_id = var.source_image_id != null ? var.source_image_id : (
+    var.source_image_from_gallery != null && var.source_image_reference == null ? data.azurerm_shared_image.gallery_image[0].id : null
+  )
 
   termination_notification {
     enabled = true

--- a/infrastructure/modules/virtual-desktop/variables.tf
+++ b/infrastructure/modules/virtual-desktop/variables.tf
@@ -90,7 +90,7 @@ variable "source_image_from_gallery" {
 }
 
 variable "source_image_id" {
-  description = "The resource id of an OS image, possibly in a remote subscription"
+  description = "The resource id of an OS image, possibly in a remote subscription (remember to grant 'Compute Gallery Image Reader' RBAC role)"
   type        = string
   default     = null
 }

--- a/infrastructure/modules/virtual-desktop/variables.tf
+++ b/infrastructure/modules/virtual-desktop/variables.tf
@@ -90,7 +90,7 @@ variable "source_image_from_gallery" {
 }
 
 variable "source_image_id" {
-  description = "The resource id of an OS image, possibly in a remote subscription (remember to grant 'Compute Gallery Image Reader' RBAC role)"
+  description = "The resource id of an OS image, possibly in a remote subscription. Remember to grant 'Compute Gallery Image Reader' RBAC role."
   type        = string
   default     = null
 }

--- a/infrastructure/modules/virtual-desktop/variables.tf
+++ b/infrastructure/modules/virtual-desktop/variables.tf
@@ -89,6 +89,12 @@ variable "source_image_from_gallery" {
   default = null
 }
 
+variable "source_image_id" {
+  description = "The resource id of an OS image, possibly in a remote subscription"
+  type        = string
+  default     = null
+}
+
 variable "source_image_reference" {
   type = object({
     offer     = string


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Within the Virtual Desktop module, virtual machine OS images can now be specified in three ways:
1. Source Image Reference (public images)
2. Source Image Gallery Reference (local private images)
3. Source Image ID (allows images in remote subscriptions, as long as managed identity has access)

## Context

This removes the need to copy the AVD image to a local compute gallery when updating from Dev to Prod. Azure makes that process very difficult, so this change greatly simplifies rolling out updates to the Azure Virtual Desktop image.

## Testing

Deployed to Prod Hub in order to refresh the AVD hosts to an updated image:
https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=16630&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
