### PR TITLE
fix: Postgres admin pwd Key Vault id is conditional

### DIFF
--- a/infrastructure/modules/postgresql-flexible/output.tf
+++ b/infrastructure/modules/postgresql-flexible/output.tf
@@ -1,3 +1,3 @@
 output "db_admin_pwd_keyvault_secret" {
-  value = resource.azurerm_key_vault_secret.db_admin_pwd[0].versionless_id
+  value = var.password_auth_enabled ? azurerm_key_vault_secret.db_admin_pwd[0].versionless_id : null
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Make this Terraform module output conditional on `var.password_auth_enabled`.

## Context

Prevents the module from failing to deploy if we select Entra ID authentication only.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
