### PR TITLE
Fix: storage_account_access_key in Function App module is now optional

### DIFF
--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -219,6 +219,7 @@ variable "resource_group_name" {
 variable "storage_account_access_key" {
   type        = string
   description = "The Storage Account Primary Access Key."
+  default     = null
 }
 
 variable "storage_account_name" {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

`storage_account_access_key` in Function App module is now optional

## Context

This allows us to use the Function App managed identity for storage account access. It is an optional parameter after all:
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
