### PR TITLE
Fix: Add outputs to Application Insights module, optional Entra ID group memberships for App Services

### DIFF
--- a/infrastructure/modules/app-insights/output.tf
+++ b/infrastructure/modules/app-insights/output.tf
@@ -1,8 +1,15 @@
-
 output "connection_string" {
   value = azurerm_application_insights.appins.connection_string
 }
 
 output "id" {
   value = azurerm_application_insights.appins.id
+}
+
+output "name" {
+  value = azurerm_application_insights.appins.name
+}
+
+output "resource_group_name" {
+  value = azurerm_application_insights.appins.resource_group_name
 }

--- a/infrastructure/modules/function-app/entra_id_group.tf
+++ b/infrastructure/modules/function-app/entra_id_group.tf
@@ -1,0 +1,6 @@
+resource "azuread_group_member" "function_app" {
+  for_each = var.entra_id_group_ids
+
+  group_object_id  = each.key
+  member_object_id = azurerm_linux_function_app.function_app.identity.0.principal_id
+}

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -52,6 +52,11 @@ variable "cors_allowed_origins" {
   default = [""]
 }
 
+variable "entra_id_group_ids" {
+  type    = list(string)
+  default = []
+}
+
 variable "ftp_publish_basic_authentication_enabled" {
   type        = bool
   description = "Enable basic authentication for FTP. Defaults to false."

--- a/infrastructure/modules/linux-web-app/entra_id_group.tf
+++ b/infrastructure/modules/linux-web-app/entra_id_group.tf
@@ -2,5 +2,5 @@ resource "azuread_group_member" "function_app" {
   for_each = toset(var.entra_id_group_ids)
 
   group_object_id  = each.key
-  member_object_id = azurerm_linux_function_app.function_app.identity.0.principal_id
+  member_object_id = azurerm_linux_web_app.this.identity.0.principal_id
 }

--- a/infrastructure/modules/linux-web-app/variables.tf
+++ b/infrastructure/modules/linux-web-app/variables.tf
@@ -47,6 +47,11 @@ variable "docker_image_name" {
   default = ""
 }
 
+variable "entra_id_group_ids" {
+  type    = list(string)
+  default = []
+}
+
 variable "ftp_publish_basic_authentication_enabled" {
   type        = bool
   description = "Enable basic authentication for FTP. Defaults to false."

--- a/infrastructure/modules/sql-server/main.tf
+++ b/infrastructure/modules/sql-server/main.tf
@@ -20,7 +20,10 @@ resource "azurerm_mssql_server" "azure_sql_server" {
   }
 
   lifecycle {
-    ignore_changes = [tags]
+    ignore_changes = [
+      tags,
+      express_vulnerability_assessment_enabled
+    ]
   }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

1. Adds `name` and `resource_group_name` outputs to Application Insights module.
2. Adds optional Entra ID group memberships for App Services (Function App, Web App).

Neither of these changes is impactful to existing code with module dependencies.

## Context

1. Will allow direct resource references between App Services in `tf-core` Terraform state, and Application Insights in`tf-audit` Terraform state. Allows the removal of some parameterisation from tfvars for stronger coupling.
2. Will allow replacement of individual RBAC roles per App Service with RBAC roles assigned via group memberships. Will greatly reduce Terraform deployment times for Cohort Manager (many Function Apps), but will need admin rights over an Organization Unit within Entra ID which is a request pending with CCOE team.

## Testing:
- Successfully deployed to Participant Manager Dev (Audit):
   https://dev.azure.com/nhse-dtos/dtos-participant-manager/_build/results?buildId=17666&view=results
- Successfully deployed to Participant Manager Dev (Core):
   https://dev.azure.com/nhse-dtos/dtos-participant-manager/_build/results?buildId=17670&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
