### PR TITLE
feat: DTOSS-9083 ACME certificate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This repository contains terraform modules and Azure devops pipeline steps to de
 After working on terraform modules, always update the terraform documentation by running:
 
 ```shell
+brew install terraform-docs
 make terraform-docs
 ```
 

--- a/infrastructure/modules/acme-certificate/main.tf
+++ b/infrastructure/modules/acme-certificate/main.tf
@@ -1,0 +1,76 @@
+resource "random_password" "pfx" {
+  length  = 30
+  special = true
+}
+
+# Terraform Managed Identity will need DNS Contributor RBAC role on the DNS Zones being altered.
+# Create CNAME record for any redirected DNS-01 challenges. Lego azuredns provider will validate this before allowing a redirected AZURE_ZONE_NAME.
+resource "azurerm_dns_cname_record" "challenge_redirect" {
+  count = var.certificate.dns_cname_zone_name != null ? 1 : 0
+
+  provider = azurerm.dns_public
+
+  name                = trim("_acme-challenge.${trim(replace(var.certificate.common_name, ".${var.certificate.dns_cname_zone_name}", ""), "*.")}", ".")
+  zone_name           = var.certificate.dns_cname_zone_name
+  resource_group_name = coalesce(var.certificate.dns_challenge_zone_rg_name, var.public_dns_zone_resource_group_name)
+  ttl                 = 300
+  record              = "${trim("_acme-challenge.${replace(split(".", var.certificate.common_name)[0], "*", "")}", ".")}.${var.certificate.dns_challenge_zone_name}"
+}
+
+# A Private DNS zone that overlaps the public namespace also needs the challenge CNAME record to pass Lego azuredns checks. Private DNS is regional.
+resource "azurerm_private_dns_cname_record" "challenge_redirect_private" {
+  for_each = var.certificate.dns_private_cname_zone_name != null ? var.private_dns_zone_resource_groups : {}
+
+  provider = azurerm.dns_private
+
+  name                = trim("_acme-challenge.${trim(replace(var.certificate.common_name, ".${var.certificate.dns_private_cname_zone_name}", ""), "*.")}", ".")
+  zone_name           = var.certificate.dns_private_cname_zone_name
+  resource_group_name = each.value.name
+  ttl                 = 300
+  record              = azurerm_dns_cname_record.challenge_redirect[0].record
+}
+
+resource "acme_certificate" "this" {
+  account_key_pem           = var.acme_registration_account_key_pem
+  common_name               = var.certificate.common_name
+  subject_alternative_names = var.certificate.subject_alternative_names
+  key_type                  = var.certificate.key_type
+  certificate_p12_password  = random_password.pfx.result
+
+  dns_challenge {
+    provider = "azuredns"
+    config = { # https://go-acme.github.io/lego/dns/azuredns/
+      # AZURE_AUTH_METHOD     = "cli"
+      AZURE_SUBSCRIPTION_ID = var.subscription_id_dns_public
+      AZURE_RESOURCE_GROUP  = lookup(var.certificate, "zone_rg_name", var.public_dns_zone_resource_group_name)
+      AZURE_ZONE_NAME       = var.certificate.dns_challenge_zone_name
+    }
+  }
+
+  depends_on = [
+    azurerm_dns_cname_record.challenge_redirect,
+    azurerm_private_dns_cname_record.challenge_redirect_private
+  ]
+}
+
+resource "azurerm_key_vault_certificate" "acme" {
+  for_each = var.key_vaults
+
+  name         = replace(replace(var.certificate.common_name, "*.", "wildcard-"), ".", "-")
+  key_vault_id = each.value.key_vault_id
+
+  certificate {
+    contents = acme_certificate.this.certificate_p12
+    password = random_password.pfx.result
+  }
+}
+
+# Workaround while App Service cannot import elliptic curve Key Vault Certificate objects
+resource "azurerm_key_vault_secret" "acme" {
+  for_each = var.key_vaults
+
+  name         = "pfx-${replace(replace(var.certificate.common_name, "*.", "wildcard-"), ".", "-")}"
+  key_vault_id = each.value.key_vault_id
+  value        = acme_certificate.this.certificate_p12
+  content_type = "application/x-pkcs12"
+}

--- a/infrastructure/modules/acme-certificate/output.tf
+++ b/infrastructure/modules/acme-certificate/output.tf
@@ -1,0 +1,16 @@
+output "key_vault_certificate" {
+  value = {
+    for k, v in azurerm_key_vault_certificate.acme : k => {
+      name                  = v.name
+      naming_key            = var.certificate_naming_key
+      subject               = var.certificate.common_name
+      location              = k
+      pfx_blob_secret_name  = azurerm_key_vault_secret.acme[k].name
+      pfx_password          = random_password.pfx.result
+      id                    = v.id
+      versionless_id        = v.versionless_id
+      versionless_secret_id = v.versionless_secret_id
+    }
+  }
+  sensitive = true
+}

--- a/infrastructure/modules/acme-certificate/providers.tf
+++ b/infrastructure/modules/acme-certificate/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      configuration_aliases = [
+        azurerm.dns_public,
+        azurerm.dns_private
+      ]
+    }
+
+    acme = {
+      source  = "vancluever/acme"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/infrastructure/modules/acme-certificate/variables.tf
+++ b/infrastructure/modules/acme-certificate/variables.tf
@@ -1,0 +1,42 @@
+variable "acme_registration_account_key_pem" {
+  # https://registry.terraform.io/providers/vancluever/acme/latest/docs/resources/registration
+  description = "Account key for the ACME registration, created once in the root module."
+  type        = string
+}
+
+variable "certificate" {
+  # https://registry.terraform.io/providers/vancluever/acme/latest/docs/resources/certificate
+  description = "Details of ACME certificate to be requested."
+  type = object({
+    common_name                 = string
+    subject_alternative_names   = optional(list(string))
+    dns_cname_zone_name         = optional(string) # CNAME for redirecting DNS-01 challenges
+    dns_private_cname_zone_name = optional(string) # CNAME for redirecting DNS-01 challenges
+    dns_challenge_zone_name     = string
+    dns_challenge_zone_rg_name  = optional(string)         # Allows override per certificate if needed
+    key_type                    = optional(string, "P256") # Follow certbot default of ECDSA P256
+  })
+}
+
+variable "certificate_naming_key" {
+  type = string
+}
+
+variable "key_vaults" {
+  description = "Key Vaults to store the certificates in, keyed by region."
+  type        = map(any)
+}
+
+variable "private_dns_zone_resource_groups" {
+  description = "Private DNS Zone Resource Groups, keyed by region. Optionally used to satisfy Lego azuredns checks for CNAME redirections of DNS-01 challenges."
+  type        = map(any)
+  default     = null
+}
+
+variable "public_dns_zone_resource_group_name" {
+  type = string
+}
+
+variable "subscription_id_dns_public" {
+  type = string
+}

--- a/infrastructure/modules/api-management/tfdocs.md
+++ b/infrastructure/modules/api-management/tfdocs.md
@@ -120,9 +120,64 @@ Type: `string`
 
 Default: `"MSAL-2"`
 
-### <a name="input_developer_portal_hostname_configuration"></a> [developer\_portal\_hostname\_configuration](#input\_developer\_portal\_hostname\_configuration)
+### <a name="input_custom_domains_developer_portal"></a> [custom\_domains\_developer\_portal](#input\_custom\_domains\_developer\_portal)
 
-Description: Developer Portal hostname configurations.
+Description: List of Custom Domains configurations for the Developer Portal endpoint.
+
+Type:
+
+```hcl
+list(object({
+    host_name                    = string
+    key_vault_id                 = optional(string)
+    certificate                  = optional(string)
+    certificate_password         = optional(string)
+    negotiate_client_certificate = optional(bool, false)
+  }))
+```
+
+Default: `[]`
+
+### <a name="input_custom_domains_gateway"></a> [custom\_domains\_gateway](#input\_custom\_domains\_gateway)
+
+Description: List of Custom Domains configurations for the Gateway endpoint.
+
+Type:
+
+```hcl
+list(object({
+    host_name                    = string
+    default_ssl_binding          = optional(bool, false)
+    key_vault_id                 = optional(string)
+    certificate                  = optional(string)
+    certificate_password         = optional(string)
+    negotiate_client_certificate = optional(bool, false)
+  }))
+```
+
+Default: `[]`
+
+### <a name="input_custom_domains_management"></a> [custom\_domains\_management](#input\_custom\_domains\_management)
+
+Description: List of Custom Domains configurationd for the Management endpoint.
+
+Type:
+
+```hcl
+list(object({
+    host_name                    = string
+    key_vault_id                 = optional(string)
+    certificate                  = optional(string)
+    certificate_password         = optional(string)
+    negotiate_client_certificate = optional(bool, false)
+  }))
+```
+
+Default: `[]`
+
+### <a name="input_custom_domains_scm"></a> [custom\_domains\_scm](#input\_custom\_domains\_scm)
+
+Description: List of Custom Domains configurations for the SCM endpoint.
 
 Type:
 
@@ -162,24 +217,6 @@ Type: `string`
 
 Default: `"SystemAssigned"`
 
-### <a name="input_management_hostname_configuration"></a> [management\_hostname\_configuration](#input\_management\_hostname\_configuration)
-
-Description: List of management hostname configurations.
-
-Type:
-
-```hcl
-list(object({
-    host_name                    = string
-    key_vault_id                 = optional(string)
-    certificate                  = optional(string)
-    certificate_password         = optional(string)
-    negotiate_client_certificate = optional(bool, false)
-  }))
-```
-
-Default: `[]`
-
 ### <a name="input_metric_enabled"></a> [metric\_enabled](#input\_metric\_enabled)
 
 Description: to enable retention for diagnostic settings metric
@@ -212,25 +249,6 @@ Type: `list(string)`
 
 Default: `null`
 
-### <a name="input_proxy_hostname_configuration"></a> [proxy\_hostname\_configuration](#input\_proxy\_hostname\_configuration)
-
-Description: List of proxy hostname configurations.
-
-Type:
-
-```hcl
-list(object({
-    host_name                    = string
-    default_ssl_binding          = optional(bool, false)
-    key_vault_id                 = optional(string)
-    certificate                  = optional(string)
-    certificate_password         = optional(string)
-    negotiate_client_certificate = optional(bool, false)
-  }))
-```
-
-Default: `[]`
-
 ### <a name="input_public_ip_address_id"></a> [public\_ip\_address\_id](#input\_public\_ip\_address\_id)
 
 Description: The ID of the public IP address to associate with the API Management service.
@@ -238,24 +256,6 @@ Description: The ID of the public IP address to associate with the API Managemen
 Type: `string`
 
 Default: `null`
-
-### <a name="input_scm_hostname_configuration"></a> [scm\_hostname\_configuration](#input\_scm\_hostname\_configuration)
-
-Description: List of SCM hostname configurations.
-
-Type:
-
-```hcl
-list(object({
-    host_name                    = string
-    key_vault_id                 = optional(string)
-    certificate                  = optional(string)
-    certificate_password         = optional(string)
-    negotiate_client_certificate = optional(bool, false)
-  }))
-```
-
-Default: `[]`
 
 ### <a name="input_sign_in_enabled"></a> [sign\_in\_enabled](#input\_sign\_in\_enabled)
 
@@ -349,4 +349,5 @@ Description: The system-assigned identity of the API Management service.
 The following resources are used by this module:
 
 - [azurerm_api_management.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management) (resource)
+- [azurerm_api_management_custom_domain.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_custom_domain) (resource)
 - [azurerm_api_management_identity_provider_aad.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_identity_provider_aad) (resource)

--- a/infrastructure/modules/api-management/variables.tf
+++ b/infrastructure/modules/api-management/variables.tf
@@ -45,8 +45,48 @@ variable "certificate_details" {
   default = []
 }
 
-variable "developer_portal_hostname_configuration" {
-  description = "Developer Portal hostname configurations."
+variable "custom_domains_developer_portal" {
+  description = "List of Custom Domains configurations for the Developer Portal endpoint."
+  type = list(object({
+    host_name                    = string
+    key_vault_id                 = optional(string)
+    certificate                  = optional(string)
+    certificate_password         = optional(string)
+    negotiate_client_certificate = optional(bool, false)
+  }))
+  default  = []
+  nullable = false
+}
+
+variable "custom_domains_gateway" {
+  description = "List of Custom Domains configurations for the Gateway endpoint."
+  type = list(object({
+    host_name                    = string
+    default_ssl_binding          = optional(bool, false)
+    key_vault_id                 = optional(string)
+    certificate                  = optional(string)
+    certificate_password         = optional(string)
+    negotiate_client_certificate = optional(bool, false)
+  }))
+  default  = []
+  nullable = false
+}
+
+variable "custom_domains_management" {
+  description = "List of Custom Domains configurationd for the Management endpoint."
+  type = list(object({
+    host_name                    = string
+    key_vault_id                 = optional(string)
+    certificate                  = optional(string)
+    certificate_password         = optional(string)
+    negotiate_client_certificate = optional(bool, false)
+  }))
+  default  = []
+  nullable = false
+}
+
+variable "custom_domains_scm" {
+  description = "List of Custom Domains configurations for the SCM endpoint."
   type = list(object({
     host_name                    = string
     key_vault_id                 = optional(string)
@@ -89,19 +129,6 @@ variable "log_analytics_workspace_id" {
   description = "id of the log analytics workspace to send resource logging to via diagnostic settings"
 }
 
-variable "management_hostname_configuration" {
-  description = "List of management hostname configurations."
-  type = list(object({
-    host_name                    = string
-    key_vault_id                 = optional(string)
-    certificate                  = optional(string)
-    certificate_password         = optional(string)
-    negotiate_client_certificate = optional(bool, false)
-  }))
-  default  = []
-  nullable = false
-}
-
 variable "metric_enabled" {
   type        = bool
   description = "to enable retention for diagnostic settings metric"
@@ -126,20 +153,6 @@ variable "monitor_diagnostic_setting_apim_metrics" {
   default     = null
 }
 
-variable "proxy_hostname_configuration" {
-  description = "List of proxy hostname configurations."
-  type = list(object({
-    host_name                    = string
-    default_ssl_binding          = optional(bool, false)
-    key_vault_id                 = optional(string)
-    certificate                  = optional(string)
-    certificate_password         = optional(string)
-    negotiate_client_certificate = optional(bool, false)
-  }))
-  default  = []
-  nullable = false
-}
-
 variable "public_ip_address_id" {
   description = "The ID of the public IP address to associate with the API Management service."
   type        = string
@@ -158,19 +171,6 @@ variable "publisher_email" {
 variable "publisher_name" {
   description = "The name of the publisher of the API Management service."
   type        = string
-}
-
-variable "scm_hostname_configuration" {
-  description = "List of SCM hostname configurations."
-  type = list(object({
-    host_name                    = string
-    key_vault_id                 = optional(string)
-    certificate                  = optional(string)
-    certificate_password         = optional(string)
-    negotiate_client_certificate = optional(bool, false)
-  }))
-  default  = []
-  nullable = false
 }
 
 variable "sign_in_enabled" {
@@ -251,9 +251,9 @@ variable "zones" {
 }
 
 
-/*_________________________________________________
-  API Management AAD Identity Provider variables.
-_________________________________________________*/
+/* --------------------------------------------------------------------------------------------------
+  API Management Entra ID Identity Provider variables
+-------------------------------------------------------------------------------------------------- */
 
 variable "allowed_tenants" {
   description = "A list of allowed tenants for the API Management AAD Identity Provider."

--- a/infrastructure/modules/app-service-plan/certificate.tf
+++ b/infrastructure/modules/app-service-plan/certificate.tf
@@ -7,6 +7,7 @@ resource "azurerm_app_service_certificate" "wildcard" {
 
   app_service_plan_id = azurerm_service_plan.appserviceplan.id
   pfx_blob            = data.azurerm_key_vault_secret.pfx_blob[0].value
+  password            = var.wildcard_ssl_cert_pfx_password
 }
 
 data "azurerm_key_vault_secret" "pfx_blob" {

--- a/infrastructure/modules/app-service-plan/tfdocs.md
+++ b/infrastructure/modules/app-service-plan/tfdocs.md
@@ -261,6 +261,14 @@ Description: Wildcard SSL certificate pfx blob Key Vault secret name, for Custom
 Type: `string`
 
 Default: `null`
+
+### <a name="input_wildcard_ssl_cert_pfx_password"></a> [wildcard\_ssl\_cert\_pfx\_password](#input\_wildcard\_ssl\_cert\_pfx\_password)
+
+Description: Wildcard SSL certificate pfx password, for Custom Domain binding.
+
+Type: `string`
+
+Default: `null`
 ## Modules
 
 The following Modules are called:

--- a/infrastructure/modules/app-service-plan/variables.tf
+++ b/infrastructure/modules/app-service-plan/variables.tf
@@ -65,6 +65,12 @@ variable "wildcard_ssl_cert_pfx_blob_key_vault_secret_name" {
   default     = null
 }
 
+variable "wildcard_ssl_cert_pfx_password" {
+  type        = string
+  description = "Wildcard SSL certificate pfx password, for Custom Domain binding."
+  default     = null
+}
+
 variable "wildcard_ssl_cert_key_vault_id" {
   type        = string
   description = "Wildcard SSL certificate Key Vault id, needed if the Key Vault is in a different subscription."

--- a/infrastructure/modules/application-gateway/main.tf
+++ b/infrastructure/modules/application-gateway/main.tf
@@ -32,7 +32,8 @@ resource "azurerm_application_gateway" "this" {
   }
 
   ssl_policy {
-    min_protocol_version = var.min_tls_ver
+    policy_type = "Predefined"
+    policy_name = var.ssl_policy_name
   }
 
   dynamic "frontend_port" {

--- a/infrastructure/modules/application-gateway/tfdocs.md
+++ b/infrastructure/modules/application-gateway/tfdocs.md
@@ -199,13 +199,13 @@ Type: `number`
 
 Default: `null`
 
-### <a name="input_min_tls_ver"></a> [min\_tls\_ver](#input\_min\_tls\_ver)
+### <a name="input_ssl_policy_name"></a> [ssl\_policy\_name](#input\_ssl\_policy\_name)
 
-Description: Minimum allowed version of TLS
+Description: n/a
 
 Type: `string`
 
-Default: `"TLSv1_2"`
+Default: `"AppGwSslPolicy20220101"`
 
 ### <a name="input_tags"></a> [tags](#input\_tags)
 

--- a/infrastructure/modules/application-gateway/variables.tf
+++ b/infrastructure/modules/application-gateway/variables.tf
@@ -99,11 +99,6 @@ variable "probe" {
   }))
 }
 
-variable "min_tls_ver" {
-  description = "Minimum allowed version of TLS"
-  default     = "TLSv1_2"
-}
-
 variable "names" {
   description = "A map containing configuration object names for the Application Gateway."
   type        = any
@@ -137,6 +132,12 @@ variable "ssl_certificate" {
     key_vault_secret_id = optional(string)
     password            = optional(string)
   }))
+}
+
+variable "ssl_policy_name" {
+  # https://learn.microsoft.com/en-us/azure/application-gateway/application-gateway-ssl-policy-overview
+  type    = string
+  default = "AppGwSslPolicy20220101"
 }
 
 variable "tags" {

--- a/infrastructure/modules/container-app-environment/output.tf
+++ b/infrastructure/modules/container-app-environment/output.tf
@@ -1,9 +1,9 @@
 output "id" {
   description = "Container app environment ID"
-  value = azurerm_container_app_environment.main.id
+  value       = azurerm_container_app_environment.main.id
 }
 
 output "default_domain" {
   description = "Default internal DNS domain. Should be registered in the private DNS zone."
-  value = azurerm_container_app_environment.main.default_domain
+  value       = azurerm_container_app_environment.main.default_domain
 }

--- a/infrastructure/modules/container-app-environment/providers.tf
+++ b/infrastructure/modules/container-app-environment/providers.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      configuration_aliases = [ azurerm.dns ]
+      source                = "hashicorp/azurerm"
+      configuration_aliases = [azurerm.dns]
     }
   }
 }

--- a/infrastructure/modules/container-app-environment/variables.tf
+++ b/infrastructure/modules/container-app-environment/variables.tf
@@ -19,7 +19,7 @@ variable "vnet_integration_subnet_id" {
 }
 
 variable "private_dns_zone_rg_name" {
-  type = string
+  type        = string
   description = "Name of the hub resource group where the private DNS zone is located."
 }
 

--- a/infrastructure/modules/container-app/output.tf
+++ b/infrastructure/modules/container-app/output.tf
@@ -1,4 +1,4 @@
 output "url" {
   description = "URL of the container app. Only available if is_web_app is true."
-  value = var.is_web_app ? "https://${azurerm_container_app.main.ingress[0].fqdn}" : ""
+  value       = var.is_web_app ? "https://${azurerm_container_app.main.ingress[0].fqdn}" : ""
 }

--- a/infrastructure/modules/lets-encrypt-certificates/README.md
+++ b/infrastructure/modules/lets-encrypt-certificates/README.md
@@ -1,5 +1,7 @@
 # lets-encrypt-certificates
 
+> ⚠️ **Note:** This module is now deprecated - replaced by module 'acme-certificate'.
+
 A Terraform module to obtain publicly trusted SSL certificates from the Let's Encrypt Certificate Authority. This module addresses the lack of a native, integrated certificate management solution in Azure, equivalent to AWS Certificate Manager.
 
 ## Features

--- a/infrastructure/modules/lets-encrypt-certificates/main.tf
+++ b/infrastructure/modules/lets-encrypt-certificates/main.tf
@@ -1,3 +1,5 @@
+# This module is now deprecated - replaced by module 'acme-certificate'.
+
 # This INI file is used by the Azure DNS plugin for certbot to allow automation of the DNS TXT record challenges
 resource "local_file" "certbot_ini_file" {
   filename        = ".terraform/certbot_dns.ini"

--- a/infrastructure/modules/lets-encrypt-certificates/tfdocs.md
+++ b/infrastructure/modules/lets-encrypt-certificates/tfdocs.md
@@ -62,10 +62,6 @@ Type: `string`
 
 The following outputs are exported:
 
-### <a name="output_key_vault_certificate_pfx_blobs"></a> [key\_vault\_certificate\_pfx\_blobs](#output\_key\_vault\_certificate\_pfx\_blobs)
-
-Description: n/a
-
 ### <a name="output_key_vault_certificates"></a> [key\_vault\_certificates](#output\_key\_vault\_certificates)
 
 Description: key is "${cert\_key}-${region}"
@@ -77,4 +73,3 @@ The following resources are used by this module:
 - [null_resource.letsencrypt_cert](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) (resource)
 - [azurerm_dns_zone.lookup](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/dns_zone) (data source)
 - [azurerm_key_vault_certificate.letsencrypt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_certificate) (data source)
-- [azurerm_key_vault_secret.pfx_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) (data source)

--- a/infrastructure/modules/lets-encrypt-certificates/variables.tf
+++ b/infrastructure/modules/lets-encrypt-certificates/variables.tf
@@ -1,3 +1,5 @@
+# This module is now deprecated - replaced by module 'acme-certificate'.
+
 variable "certificates" {
   description = "Map of certificates names with their subject names (DNS names)."
   type        = map(string)

--- a/infrastructure/modules/linux-web-app/providers.tf
+++ b/infrastructure/modules/linux-web-app/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source                = "hashicorp/azurerm"
       configuration_aliases = [azurerm.dns]
     }
   }

--- a/infrastructure/modules/shared-config/output.tf
+++ b/infrastructure/modules/shared-config/output.tf
@@ -61,10 +61,10 @@ locals {
         parman_www_prd = lower("parman-www-prd-htst-${var.env}-${var.location_map[var.location]}-${var.application}")
       }
       ssl_certificate_name = {
-        nationalscreening_private = "lets-encrypt-nationalscreening-wildcard-private"
-        nationalscreening_public  = "lets-encrypt-nationalscreening-wildcard-public"
-        screening_private         = "lets-encrypt-screening-wildcard-private"
-        screening_public          = "lets-encrypt-screening-wildcard-public"
+        nationalscreening_wildcard_private = "lets-encrypt-nationalscreening-wildcard-private"
+        nationalscreening_wildcard         = "lets-encrypt-nationalscreening-wildcard-public"
+        screening_wildcard_private         = "lets-encrypt-screening-wildcard-private"
+        screening_wildcard                 = "lets-encrypt-screening-wildcard-public"
       }
       http_listener_name = {
         apim_gateway_public   = lower("apim-gateway-pub-listener-${var.env}-${var.location_map[var.location]}-${var.application}")

--- a/infrastructure/modules/virtual-desktop/main.tf
+++ b/infrastructure/modules/virtual-desktop/main.tf
@@ -29,6 +29,10 @@ resource "azurerm_virtual_desktop_host_pool" "this" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [load_balancer_type] # will vary with scaling plan
+  }
 }
 
 resource "azurerm_virtual_desktop_host_pool_registration_info" "registrationinfo" {

--- a/infrastructure/modules/virtual-desktop/main.tf
+++ b/infrastructure/modules/virtual-desktop/main.tf
@@ -31,7 +31,7 @@ resource "azurerm_virtual_desktop_host_pool" "this" {
   tags = var.tags
 
   lifecycle {
-    ignore_changes = [load_balancer_type] # will vary with scaling plan
+    ignore_changes = [load_balancer_type] # will vary throughout the day as scaling plan operates
   }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
A new Terraform module for ACME Certificate, to replace the unconventional Let's Encrypt Certificates module.

### letsencrypt-certificates module:
➕ Underpinned by [certbot](https://github.com/certbot/certbot).
➕ Very reliable advanced certificate/DNS challenge automation.
➖ Had to use null resource, so although idempotent it was not truly Terrform stateful.
➕ Very simple module inputs.
➖ Implicit DNS challenge behaviour.
➖ Extensive custom code, implying a maintenance and comprehension overhead.
➖ Serial certificate processing.

### acme-certificate module:
➕ Underpinned by [lego](https://github.com/go-acme/lego).
➖ Well maintained, but lego azuredns DNS challenge has more constraints and corner cases than certbot - which must be handled: mandatory leaf zone NS record checks, which then require CNAME redirects for DNS Challenge, which in turn require a workaround for split brain Private DNS zone interference.
➕ Uses third party [vancluever/acme](https://registry.terraform.io/providers/vancluever/acme/latest/docs) provider, well maintained by a former HashiCorp employee - so properly Terraform stateful.
➖ Slightly more inputs, but...
➕ Explicit rather than implicit DNS challenge behaviour, with full control via optional module inputs.
➕ A small amount of custom Terraform code, easier to maintain and understand.
➕ Parallel certificate processing.

## Additional changes:
- Reduced other sources of `terraform plan` noise (AVD Host Pool load balancer type, GitHub Actions delegated subnet (via azapi) metadata & tags, Application Gateway ssl_policy).
- Separated the API Management Custom Domains config from the main resource into a newer dedicated resource type, which has overcome an inconsistent ordering bug that was also causing terraform to interpret many unnecessary changes needed on every plan.

Linked to:
- https://github.com/NHSDigital/dtos-hub/pull/89
- https://github.com/NHSDigital/dtos-participant-manager/pull/165
- https://github.com/NHSDigital/dtos-cohort-manager/pull/1001

## Testing

Successfully deployed to Non-Live Hub:
https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=18466&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
