### PR TITLE
fix: ACME certificate module simplification & fix

### DIFF
--- a/infrastructure/modules/acme-certificate/README.md
+++ b/infrastructure/modules/acme-certificate/README.md
@@ -7,7 +7,7 @@ A Terraform module to obtain publicly trusted SSL certificates from the Let's En
 - Uses the [vancluever/acme](https://registry.terraform.io/providers/vancluever/acme/latest/docs) provider for true stateful certificate management in Terraform, backed by [Lego](https://github.com/go-acme/lego) as the ACME implementation.
 - Seamless certificate renewal within 30 days of expiry.
 - Automates [DNS-01 challenges](https://letsencrypt.org/docs/challenge-types/) via the [Lego azuredns](https://go-acme.github.io/lego/dns/azuredns/) provider.
-- Handles Lego's requirement for authoritative NS records on the leaf zone. e.g. if you need a certificate for `www.private.mydomain.com` but don't have a `private.mydomain.com` zone, you can use CNAME redirection.
+- Handles Lego's requirement for authoritative NS records on the leaf zone. e.g. if you need a certificate for `www.private.example.com` but only have a zone for `example.com`, you can use CNAME redirection (see examples below).
 - CNAME redirection of DNS challenge records, including optional creation of corresponding CNAMEs in Azure Private DNS zones to satisfy Lego's local checks (wildcards supported).
 - Stores certificates in Azure Key Vault as Certificate objects.
 - Also stores the certificate as a `.pfx` file in a base64-encoded Key Vault Secret with a strong randomised password, for compatibility with consumers that cannot use Certificate objects.
@@ -18,29 +18,30 @@ A Terraform module to obtain publicly trusted SSL certificates from the Let's En
 
 **example.tfvars**
 ```hcl
-acme_certificates = {
-  screening_wildcard = {
-    common_name             = "*.non-live.screening.nhs.uk"
-    dns_challenge_zone_name = "non-live.screening.nhs.uk"
+acme_certificates = {                                  # RESULT
+  simple = {
+    common_name             = "*.example.com"          # Wildcards are stripped
+    dns_challenge_zone_name = "example.com"            # TXT _acme-challenge.example.com
   }
-  screening_www_private = {
-    common_name             = "www.private.non-live.screening.nhs.uk"           # No Azure DNS zone for 'private', so we need a CNAME redirect
-    dns_cname_zone_name     = "non-live.screening.nhs.uk"                       # CNAME: _acme-challenge.www.private -> _acme-challenge.www.acme.non-live.screening.nhs.uk
-    dns_challenge_zone_name = "acme.non-live.screening.nhs.uk"                  # TXT: _acme-challenge.www.acme.non-live.screening.nhs.uk
+  redirected = {
+    common_name             = "www.foo.example.com"    # No Azure DNS zone for 'foo', use a CNAME to redirect DNS-01 challenge
+    dns_cname_zone_name     = "example.com"            # CNAME _acme-challenge.www.foo resolving to the below record
+    dns_challenge_zone_name = "acme.example.com"       # TXT _acme-challenge.www.foo.acme.example.com
   }
-  nationalscreening_wildcard_private = {
-    common_name                 = "*.private.non-live.nationalscreening.nhs.uk" # In this example we also have a private DNS zone of the same name
-    dns_cname_zone_name         = "non-live.nationalscreening.nhs.uk"           # CNAME: _acme-challenge.private -> _acme-challenge.acme.non-live.nationalscreening.nhs.uk
-    dns_private_cname_zone_name = "private.non-live.nationalscreening.nhs.uk"   # Same CNAME added into existing private zone, to satisfy Lego's checks
-    dns_challenge_zone_name     = "acme.non-live.nationalscreening.nhs.uk"      # TXT: _acme-challenge.acme.non-live.nationalscreening.nhs.uk
+  redirected_split_horizon = {
+    common_name                 = "*.bar.example.com"  # In this example we also have a private DNS zone bar.example.com
+    dns_cname_zone_name         = "example.com"        # CNAME _acme-challenge.bar resolving to the below record
+    dns_challenge_zone_name     = "acme.example.com"   # TXT _acme-challenge.bar.acme.example.com
+    dns_private_cname_zone_name = "bar.example.com"    # CNAME _acme-challenge resolving to the above record (satisfying Lego checks)
   }
 }
 ```
+> ⚠️ `dns_cname_zone_name` and `dns_private_cname_zone_name` must match part of `common_name`, while `dns_challenge_zone_name` can be any public zone you control.
 
 **certificate.tf**
 ```hcl
 resource "acme_registration" "hub" {
-  email_address = var.LETS_ENCRYPT_CONTACT_EMAIL
+  email_address = var.acme_contact_email
 }
 
 module "acme_certificate" {
@@ -60,8 +61,32 @@ module "acme_certificate" {
   key_vaults                          = module.key_vault
   private_dns_zone_resource_groups    = azurerm_resource_group.private_dns_rg
   public_dns_zone_resource_group_name = var.dns_zone_rg_name_public
-  subscription_id_dns_public          = var.TARGET_SUBSCRIPTION_ID
+  subscription_id_dns_public          = var.subscription_id_target
 }
+```
+
+To reference a resulting Key Vault Certificate:
+```hcl
+module.acme_certificate["simple"].key_vault_certificate["uksouth"].versionless_secret_id
+```
+
+To reference a resulting `.pfx` certificate file:
+```hcl
+module.acme_certificate["simple"].key_vault_certificate["uksouth"].pfx_blob_secret_name
+module.acme.certificate["simple"].key_vault_certificate["uksouth"].pfx_password
+```
+
+## Testing
+
+Remember to use the ACME staging API in your terraform providers block until the code works to your satisfaction.
+
+Remove your test certificates from your Terraform state before switching accounts or before switching between API endpoints. By default the provider will try to revoke certificates with ACME on destroy, and if you accidentally delete or replace the account first this will result in a continual:
+
+> _Error: acme: error: 400 :: POST :: https://acme-staging-v02.api.letsencrypt.org/acme/new-acct :: urn:ietf:params:acme:error:accountDoesNotExist :: No account exists with the provided key_
+
+which can only be resolved by manually pruning the certificates from the state file:
+```bash
+terraform state rm "module.acme_certificate[\"example\"].acme_certificate.this"
 ```
 
 ## Terraform documentation

--- a/infrastructure/modules/acme-certificate/main.tf
+++ b/infrastructure/modules/acme-certificate/main.tf
@@ -3,6 +3,12 @@ resource "random_password" "pfx" {
   special = true
 }
 
+locals {
+  common_name_no_wildcard             = replace(var.certificate.common_name, "*.", "")
+  hostname_for_cname_with_dot         = var.certificate.dns_cname_zone_name != null ? replace(local.common_name_no_wildcard, var.certificate.dns_cname_zone_name, "") : null
+  hostname_for_private_cname_with_dot = var.certificate.dns_private_cname_zone_name != null ? replace(local.common_name_no_wildcard, var.certificate.dns_private_cname_zone_name, "") : null
+}
+
 # Terraform Managed Identity will need DNS Contributor RBAC role on the DNS Zones being altered.
 # Create CNAME record for any redirected DNS-01 challenges. Lego azuredns provider will validate this before allowing a redirected AZURE_ZONE_NAME.
 resource "azurerm_dns_cname_record" "challenge_redirect" {
@@ -10,32 +16,37 @@ resource "azurerm_dns_cname_record" "challenge_redirect" {
 
   provider = azurerm.dns_public
 
-  name                = trim("_acme-challenge.${trim(replace(var.certificate.common_name, ".${var.certificate.dns_cname_zone_name}", ""), "*.")}", ".")
+  name                = trim("_acme-challenge.${local.hostname_for_cname_with_dot}", ".")
   zone_name           = var.certificate.dns_cname_zone_name
   resource_group_name = coalesce(var.certificate.dns_challenge_zone_rg_name, var.public_dns_zone_resource_group_name)
-  ttl                 = 300
-  record              = "${trim("_acme-challenge.${replace(split(".", var.certificate.common_name)[0], "*", "")}", ".")}.${var.certificate.dns_challenge_zone_name}"
+  ttl                 = 60
+  record              = "_acme-challenge.${local.hostname_for_cname_with_dot}${var.certificate.dns_challenge_zone_name}"
+
+  tags = var.tags
 }
 
 # A Private DNS zone that overlaps the public namespace also needs the challenge CNAME record to pass Lego azuredns checks. Private DNS is regional.
 resource "azurerm_private_dns_cname_record" "challenge_redirect_private" {
-  for_each = var.certificate.dns_private_cname_zone_name != null ? var.private_dns_zone_resource_groups : {}
+  for_each = (var.certificate.dns_private_cname_zone_name != null && var.certificate.dns_cname_zone_name != null) ? var.private_dns_zone_resource_groups : {}
 
   provider = azurerm.dns_private
 
-  name                = trim("_acme-challenge.${trim(replace(var.certificate.common_name, ".${var.certificate.dns_private_cname_zone_name}", ""), "*.")}", ".")
+  name                = trim("_acme-challenge.${local.hostname_for_private_cname_with_dot}", ".")
   zone_name           = var.certificate.dns_private_cname_zone_name
   resource_group_name = each.value.name
-  ttl                 = 300
+  ttl                 = 60
   record              = azurerm_dns_cname_record.challenge_redirect[0].record
+
+  tags = var.tags
 }
 
 resource "acme_certificate" "this" {
-  account_key_pem           = var.acme_registration_account_key_pem
-  common_name               = var.certificate.common_name
-  subject_alternative_names = var.certificate.subject_alternative_names
-  key_type                  = var.certificate.key_type
-  certificate_p12_password  = random_password.pfx.result
+  account_key_pem               = var.acme_registration_account_key_pem
+  common_name                   = var.certificate.common_name
+  subject_alternative_names     = var.certificate.subject_alternative_names
+  key_type                      = var.certificate.key_type
+  certificate_p12_password      = random_password.pfx.result
+  revoke_certificate_on_destroy = var.certificate.revoke_certificate_on_destroy
 
   dns_challenge {
     provider = "azuredns"
@@ -63,6 +74,8 @@ resource "azurerm_key_vault_certificate" "acme" {
     contents = acme_certificate.this.certificate_p12
     password = random_password.pfx.result
   }
+
+  tags = var.tags
 }
 
 # Workaround while App Service cannot import elliptic curve Key Vault Certificate objects
@@ -73,4 +86,6 @@ resource "azurerm_key_vault_secret" "acme" {
   key_vault_id = each.value.key_vault_id
   value        = acme_certificate.this.certificate_p12
   content_type = "application/x-pkcs12"
+
+  tags = var.tags
 }

--- a/infrastructure/modules/acme-certificate/tfdocs.md
+++ b/infrastructure/modules/acme-certificate/tfdocs.md
@@ -18,13 +18,14 @@ Type:
 
 ```hcl
 object({
-    common_name                 = string
-    subject_alternative_names   = optional(list(string))
-    dns_cname_zone_name         = optional(string) # CNAME for redirecting DNS-01 challenges
-    dns_private_cname_zone_name = optional(string) # CNAME for redirecting DNS-01 challenges
-    dns_challenge_zone_name     = string
-    dns_challenge_zone_rg_name  = optional(string)         # Allows override per certificate if needed
-    key_type                    = optional(string, "P256") # Follow certbot default of ECDSA P256
+    common_name                   = string
+    subject_alternative_names     = optional(list(string))
+    dns_cname_zone_name           = optional(string) # CNAME for redirecting DNS-01 challenges
+    dns_private_cname_zone_name   = optional(string) # CNAME for redirecting DNS-01 challenges
+    dns_challenge_zone_name       = string
+    dns_challenge_zone_rg_name    = optional(string)         # Allows override per certificate if needed
+    key_type                      = optional(string, "P256") # Follow certbot default of ECDSA P256
+    revoke_certificate_on_destroy = optional(bool, true)
   })
 ```
 
@@ -63,6 +64,14 @@ Description: Private DNS Zone Resource Groups, keyed by region. Optionally used 
 Type: `map(any)`
 
 Default: `null`
+
+### <a name="input_tags"></a> [tags](#input\_tags)
+
+Description: n/a
+
+Type: `map(string)`
+
+Default: `{}`
 
 ## Outputs
 

--- a/infrastructure/modules/acme-certificate/variables.tf
+++ b/infrastructure/modules/acme-certificate/variables.tf
@@ -8,14 +8,31 @@ variable "certificate" {
   # https://registry.terraform.io/providers/vancluever/acme/latest/docs/resources/certificate
   description = "Details of ACME certificate to be requested."
   type = object({
-    common_name                 = string
-    subject_alternative_names   = optional(list(string))
-    dns_cname_zone_name         = optional(string) # CNAME for redirecting DNS-01 challenges
-    dns_private_cname_zone_name = optional(string) # CNAME for redirecting DNS-01 challenges
-    dns_challenge_zone_name     = string
-    dns_challenge_zone_rg_name  = optional(string)         # Allows override per certificate if needed
-    key_type                    = optional(string, "P256") # Follow certbot default of ECDSA P256
+    common_name                   = string
+    subject_alternative_names     = optional(list(string))
+    dns_cname_zone_name           = optional(string) # CNAME for redirecting DNS-01 challenges
+    dns_private_cname_zone_name   = optional(string) # CNAME for redirecting DNS-01 challenges
+    dns_challenge_zone_name       = string
+    dns_challenge_zone_rg_name    = optional(string)         # Allows override per certificate if needed
+    key_type                      = optional(string, "P256") # Follow certbot default of ECDSA P256
+    revoke_certificate_on_destroy = optional(bool, true)
   })
+
+  validation {
+    condition = (
+      var.certificate.dns_cname_zone_name == null ||
+      contains(var.certificate.common_name, var.certificate.dns_cname_zone_name)
+    )
+    error_message = "dns_cname_zone_name must be a substring of common_name (e.g., for '*.api.example.com', the zone could be 'example.com')."
+  }
+
+  validation {
+    condition = (
+      var.certificate.dns_private_cname_zone_name == null ||
+      contains(var.certificate.common_name, var.certificate.dns_private_cname_zone_name)
+    )
+    error_message = "dns_private_cname_zone_name must be a substring of common_name (e.g., for '*.int.example.com', the private zone could be 'int.example.com')."
+  }
 }
 
 variable "certificate_naming_key" {
@@ -39,4 +56,9 @@ variable "public_dns_zone_resource_group_name" {
 
 variable "subscription_id_dns_public" {
   type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
 }

--- a/infrastructure/modules/application-gateway/main.tf
+++ b/infrastructure/modules/application-gateway/main.tf
@@ -99,7 +99,7 @@ resource "azurerm_application_gateway" "this" {
     content {
       data                = ssl_certificate.value.data
       key_vault_secret_id = ssl_certificate.value.key_vault_secret_id
-      name                = var.names.ssl_certificate_name[ssl_certificate.key]
+      name                = ssl_certificate.key
       password            = ssl_certificate.value.password
     }
   }
@@ -143,7 +143,7 @@ resource "azurerm_application_gateway" "this" {
       frontend_port_name             = var.names.frontend_port_name[http_listener.value.frontend_port_key]
       protocol                       = http_listener.value.protocol
       require_sni                    = http_listener.value.require_sni
-      ssl_certificate_name           = http_listener.value.ssl_certificate_key != null ? var.names.ssl_certificate_name[http_listener.value.ssl_certificate_key] : null
+      ssl_certificate_name           = http_listener.value.ssl_certificate_key
       ssl_profile_name               = http_listener.value.ssl_profile_name
     }
   }

--- a/infrastructure/modules/shared-config/output.tf
+++ b/infrastructure/modules/shared-config/output.tf
@@ -60,12 +60,6 @@ locals {
         parman_www_pre = lower("parman-www-pre-htst-${var.env}-${var.location_map[var.location]}-${var.application}")
         parman_www_prd = lower("parman-www-prd-htst-${var.env}-${var.location_map[var.location]}-${var.application}")
       }
-      ssl_certificate_name = {
-        nationalscreening_wildcard_private = "lets-encrypt-nationalscreening-wildcard-private"
-        nationalscreening_wildcard         = "lets-encrypt-nationalscreening-wildcard-public"
-        screening_wildcard_private         = "lets-encrypt-screening-wildcard-private"
-        screening_wildcard                 = "lets-encrypt-screening-wildcard-public"
-      }
       http_listener_name = {
         apim_gateway_public   = lower("apim-gateway-pub-listener-${var.env}-${var.location_map[var.location]}-${var.application}")
         apim_gateway_private  = lower("apim-gateway-priv-listener-${var.env}-${var.location_map[var.location]}-${var.application}")


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

ACME Certificate module improvements:
- Refactored and considerably simplified DNS record name string manipulations.
- Preserved full subdomain depth of redirected domains, which avoids possible DNS-01 challenge collisions when using CNAME redirection. Previously `*.foo.example.com` and `*.bar.example.com` would both have collided with a challenge at `_acme-challenge.acme.example.com`. Now they would be challenged at `_acme-challenge.foo.acme.example.com`
and `_acme-challenge.bar.acme.example.com` respectively.
- Added some basic CNAME domain validation that may not be obvious to new consumers of the module.

## Testing

- Successfully deployed to Hub Non-Live:
  https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=18561&view=results
- Successfully deployed to Hub Live:
  https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=18563&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
