### PR TITLE
fix: ACME certificate module simplification & improvements

### DIFF
--- a/infrastructure/modules/acme-certificate/main.tf
+++ b/infrastructure/modules/acme-certificate/main.tf
@@ -3,6 +3,22 @@ resource "random_password" "pfx" {
   special = true
 }
 
+locals {
+  common_name_no_wildcard = replace(var.certificate.common_name, "*.", "")
+
+  cname_relative_hostname = (
+    var.certificate.dns_cname_zone_name != null
+      ? trim(replace(local.common_name_no_wildcard, var.certificate.dns_cname_zone_name, ""), ".")
+      : null
+  )
+
+  private_cname_relative_hostname = (
+    var.certificate.dns_private_cname_zone_name != null
+      ? trim(replace(local.common_name_no_wildcard, var.certificate.dns_private_cname_zone_name, ""), ".")
+      : null
+  )
+}
+
 # Terraform Managed Identity will need DNS Contributor RBAC role on the DNS Zones being altered.
 # Create CNAME record for any redirected DNS-01 challenges. Lego azuredns provider will validate this before allowing a redirected AZURE_ZONE_NAME.
 resource "azurerm_dns_cname_record" "challenge_redirect" {
@@ -10,32 +26,38 @@ resource "azurerm_dns_cname_record" "challenge_redirect" {
 
   provider = azurerm.dns_public
 
-  name                = trim("_acme-challenge.${trim(replace(var.certificate.common_name, ".${var.certificate.dns_cname_zone_name}", ""), "*.")}", ".")
+  # Relative hostname can be "" so compact() removes empty strings to avoid extra dots in join().
+  name                = join(".", compact(["_acme-challenge", local.cname_relative_hostname]))
   zone_name           = var.certificate.dns_cname_zone_name
   resource_group_name = coalesce(var.certificate.dns_challenge_zone_rg_name, var.public_dns_zone_resource_group_name)
   ttl                 = 60
-  record              = "${trim("_acme-challenge.${replace(split(".", var.certificate.common_name)[0], "*", "")}", ".")}.${var.certificate.dns_challenge_zone_name}"
+  record              = join(".", compact(["_acme-challenge", local.cname_relative_hostname, var.certificate.dns_challenge_zone_name]))
+
+  tags = var.tags
 }
 
 # A Private DNS zone that overlaps the public namespace also needs the challenge CNAME record to pass Lego azuredns checks. Private DNS is regional.
 resource "azurerm_private_dns_cname_record" "challenge_redirect_private" {
-  for_each = var.certificate.dns_private_cname_zone_name != null ? var.private_dns_zone_resource_groups : {}
+  for_each = (var.certificate.dns_private_cname_zone_name != null && var.certificate.dns_cname_zone_name != null) ? var.private_dns_zone_resource_groups : {}
 
   provider = azurerm.dns_private
 
-  name                = trim("_acme-challenge.${trim(replace(var.certificate.common_name, ".${var.certificate.dns_private_cname_zone_name}", ""), "*.")}", ".")
+  name                = join(".", compact(["_acme-challenge", local.private_cname_relative_hostname]))
   zone_name           = var.certificate.dns_private_cname_zone_name
   resource_group_name = each.value.name
   ttl                 = 60
   record              = azurerm_dns_cname_record.challenge_redirect[0].record
+
+  tags = var.tags
 }
 
 resource "acme_certificate" "this" {
-  account_key_pem           = var.acme_registration_account_key_pem
-  common_name               = var.certificate.common_name
-  subject_alternative_names = var.certificate.subject_alternative_names
-  key_type                  = var.certificate.key_type
-  certificate_p12_password  = random_password.pfx.result
+  account_key_pem               = var.acme_registration_account_key_pem
+  common_name                   = var.certificate.common_name
+  subject_alternative_names     = var.certificate.subject_alternative_names
+  key_type                      = var.certificate.key_type
+  certificate_p12_password      = random_password.pfx.result
+  revoke_certificate_on_destroy = var.certificate.revoke_certificate_on_destroy
 
   dns_challenge {
     provider = "azuredns"
@@ -63,6 +85,8 @@ resource "azurerm_key_vault_certificate" "acme" {
     contents = acme_certificate.this.certificate_p12
     password = random_password.pfx.result
   }
+
+  tags = var.tags
 }
 
 # Workaround while App Service cannot import elliptic curve Key Vault Certificate objects
@@ -73,4 +97,6 @@ resource "azurerm_key_vault_secret" "acme" {
   key_vault_id = each.value.key_vault_id
   value        = acme_certificate.this.certificate_p12
   content_type = "application/x-pkcs12"
+
+  tags = var.tags
 }

--- a/infrastructure/modules/acme-certificate/tfdocs.md
+++ b/infrastructure/modules/acme-certificate/tfdocs.md
@@ -18,13 +18,14 @@ Type:
 
 ```hcl
 object({
-    common_name                 = string
-    subject_alternative_names   = optional(list(string))
-    dns_cname_zone_name         = optional(string) # CNAME for redirecting DNS-01 challenges
-    dns_private_cname_zone_name = optional(string) # CNAME for redirecting DNS-01 challenges
-    dns_challenge_zone_name     = string
-    dns_challenge_zone_rg_name  = optional(string)         # Allows override per certificate if needed
-    key_type                    = optional(string, "P256") # Follow certbot default of ECDSA P256
+    common_name                   = string
+    subject_alternative_names     = optional(list(string))
+    dns_cname_zone_name           = optional(string) # CNAME for redirecting DNS-01 challenges
+    dns_private_cname_zone_name   = optional(string) # CNAME for redirecting DNS-01 challenges
+    dns_challenge_zone_name       = string
+    dns_challenge_zone_rg_name    = optional(string)         # Allows override per certificate if needed
+    key_type                      = optional(string, "P256") # Follow certbot default of ECDSA P256
+    revoke_certificate_on_destroy = optional(bool, true)
   })
 ```
 
@@ -63,6 +64,14 @@ Description: Private DNS Zone Resource Groups, keyed by region. Optionally used 
 Type: `map(any)`
 
 Default: `null`
+
+### <a name="input_tags"></a> [tags](#input\_tags)
+
+Description: n/a
+
+Type: `map(string)`
+
+Default: `{}`
 
 ## Outputs
 

--- a/infrastructure/modules/acme-certificate/variables.tf
+++ b/infrastructure/modules/acme-certificate/variables.tf
@@ -8,13 +8,14 @@ variable "certificate" {
   # https://registry.terraform.io/providers/vancluever/acme/latest/docs/resources/certificate
   description = "Details of ACME certificate to be requested."
   type = object({
-    common_name                 = string
-    subject_alternative_names   = optional(list(string))
-    dns_cname_zone_name         = optional(string)         # CNAME for redirecting DNS-01 challenges
-    dns_private_cname_zone_name = optional(string)         # CNAME for redirecting DNS-01 challenges
-    dns_challenge_zone_name     = string
-    dns_challenge_zone_rg_name  = optional(string)         # Allows override per certificate if needed
-    key_type                    = optional(string, "P256") # Follow certbot default of ECDSA P256
+    common_name                   = string
+    subject_alternative_names     = optional(list(string))
+    dns_cname_zone_name           = optional(string) # CNAME for redirecting DNS-01 challenges
+    dns_private_cname_zone_name   = optional(string) # CNAME for redirecting DNS-01 challenges
+    dns_challenge_zone_name       = string
+    dns_challenge_zone_rg_name    = optional(string)         # Allows override per certificate if needed
+    key_type                      = optional(string, "P256") # Follow certbot default of ECDSA P256
+    revoke_certificate_on_destroy = optional(bool, true)
   })
 }
 
@@ -39,4 +40,9 @@ variable "public_dns_zone_resource_group_name" {
 
 variable "subscription_id_dns_public" {
   type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

ACME Certificate module improvements:
- Refactored and considerably simplified DNS record name string manipulations.
- Preserved full subdomain depth of redirected domains, which avoids possible DNS-01 challenge collisions when using CNAME redirection. Previously `*.foo.example.com` and `*.bar.example.com` would both have collided with a challenge at `_acme-challenge.acme.example.com`. Now they would be challenged at `_acme-challenge.foo.acme.example.com`
and `_acme-challenge.bar.acme.example.com` respectively.
- Added tagging of azurerm resources.

## Testing

- Successfully deployed to Hub Non-Live:
  https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=18586&view=results
- Successfully deployed to Hub Live:
  https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=18582&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
