### PR TITLE
feat: DTOSS-9032 app service plan zone balancing

### DIFF
--- a/infrastructure/modules/app-service-plan/main.tf
+++ b/infrastructure/modules/app-service-plan/main.tf
@@ -3,8 +3,9 @@ resource "azurerm_service_plan" "appserviceplan" {
   resource_group_name = var.resource_group_name
   location            = var.location
 
-  os_type  = var.os_type
-  sku_name = var.sku_name
+  os_type                = var.os_type
+  sku_name               = var.sku_name
+  zone_balancing_enabled = var.zone_balancing_enabled
 
   tags = var.tags
 

--- a/infrastructure/modules/app-service-plan/variables.tf
+++ b/infrastructure/modules/app-service-plan/variables.tf
@@ -77,6 +77,12 @@ variable "wildcard_ssl_cert_key_vault_id" {
   default     = null
 }
 
+variable "zone_balancing_enabled" {
+  type        = string
+  description = "Balance the App Service Plan across Availability Zones in the region. Changing this forces the resource to be recreated."
+  default     = null
+}
+
 ## autoscale rule ##
 
 variable "metric" {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Add optional zone balancing to App Services Plan module.

## Testing
Ensured that this new parameter does not disrupt environments that do not set this parameter.

- Participant Manager deploy - no changes:
  https://dev.azure.com/nhse-dtos/dtos-participant-manager/_build/results?buildId=18670&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
