### PR TITLE
Fix: use math.floor instead of "round" for scenarios where results ar…

### DIFF
--- a/scripts/integrations/slack/SlackMessages.py
+++ b/scripts/integrations/slack/SlackMessages.py
@@ -1,3 +1,4 @@
+import math
 from typing import Dict
 from datetime import datetime
 
@@ -52,7 +53,7 @@ def slack_message_style1_subheading(test_results, build_url):
     total_tests = test_results.get("total", 0)
 
     try:
-        green_circles = round((pass_rate / 100) * total_circles)
+        green_circles = math.floor((pass_rate / 100) * total_circles)
     except (TypeError, ZeroDivisionError):
         green_circles = 0
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
Update results star rating code to use math.floor instead of round for scenarios where results are between 95% and 100%

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
