### PR TITLE
[DTOS-9339] Fix identities error in container app module

### DIFF
--- a/infrastructure/modules/container-app/main.tf
+++ b/infrastructure/modules/container-app/main.tf
@@ -18,7 +18,11 @@ module "key_vault_reader_role" {
 
 # Merge the identity created above with any passed in via a variables list:
 locals {
-  all_identity_ids = concat([var.acr_managed_identity_id], var.user_assigned_identity_ids, [module.container_app_identity.id])
+  all_identity_ids = compact(concat(
+    [var.acr_managed_identity_id],
+    var.user_assigned_identity_ids,
+    [module.container_app_identity.id]
+  ))
 }
 
 resource "azurerm_container_app" "main" {


### PR DESCRIPTION
## Description
Remove the null values from the list. They happen when not all identities are present.

## Context
It was causing error in the manage breast screening pipeline

