### PR TITLE
fix: don't run the append hash job if the full rebuild was triggered

### DIFF
--- a/.github/workflows/stage-3-build-images.yaml
+++ b/.github/workflows/stage-3-build-images.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: NHSDigital/dtos-devops-templates
           path: templates
-          ref: fix/no-append-hash-for-full-rebuild
+          ref: main
 
       - name: Determine which Docker container(s) to build
         id: get-function-names
@@ -93,7 +93,7 @@ jobs:
         with:
           repository: NHSDigital/dtos-devops-templates
           path: templates
-          ref: fix/no-append-hash-for-full-rebuild
+          ref: main
 
       - name: Az CLI login
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/stage-3-build-images.yaml
+++ b/.github/workflows/stage-3-build-images.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: NHSDigital/dtos-devops-templates
           path: templates
-          ref: main
+          ref: fix/no-append-hash-for-full-rebuild
 
       - name: Determine which Docker container(s) to build
         id: get-function-names
@@ -93,7 +93,7 @@ jobs:
         with:
           repository: NHSDigital/dtos-devops-templates
           path: templates
-          ref: main
+          ref: fix/no-append-hash-for-full-rebuild
 
       - name: Az CLI login
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/stage-3-build-images.yaml
+++ b/.github/workflows/stage-3-build-images.yaml
@@ -252,7 +252,7 @@ jobs:
     name: "Append short commit hash to images"
     runs-on: ubuntu-latest
     needs: build-and-push
-    if: github.ref == 'refs/heads/main' && github.event.inputs.build_all_images != true
+    if: github.ref == 'refs/heads/main' && inputs.build_all_images != true
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Don't run the append hash job if the full rebuild was triggered

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
