### PR TITLE
fix: DTOSS-9562 Route table module optional var

### DIFF
--- a/infrastructure/modules/route-table/variables.tf
+++ b/infrastructure/modules/route-table/variables.tf
@@ -24,7 +24,7 @@ variable "routes" {
     name                   = string
     address_prefix         = string
     next_hop_type          = string
-    next_hop_in_ip_address = string
+    next_hop_in_ip_address = optional(string)
   }))
 
   validation {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

The module had incorrectly made the next hop parameter mandatory.

## Context

Needed for workarounds to send AVD egress traffic via Azure Firewall in https://github.com/NHSDigital/dtos-hub/pull/98

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
