### PR TITLE
fx: shorten suffix due to name length restrictions in Azure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ coverage.xml
 .prof
 __azurite_db_blob__.json
 __azurite_db_blob_extent__.json
+.idea/workspace.xml
+tools/scan-tags-compliance/scan-results/azure_resource_compliance_scan.csv
+tools/scan-tags-compliance/scan-results/azure_skipped_items.log
+tools/scan-tags-compliance/scan-results/scan_results.html

--- a/infrastructure/modules/container-registry/main.tf
+++ b/infrastructure/modules/container-registry/main.tf
@@ -23,18 +23,18 @@ module "private_endpoint_container_registry" {
 
   source = "../private-endpoint"
 
-  name                = "${var.name}-private-endpoint"
+  name                = "${var.name}-pep"
   resource_group_name = var.private_endpoint_properties.private_endpoint_resource_group_name
   location            = var.location
   subnet_id           = var.private_endpoint_properties.private_endpoint_subnet_id
 
   private_dns_zone_group = {
-    name                 = "${var.name}-private-endpoint-zone-group"
+    name                 = "${var.name}-pep-zone-group"
     private_dns_zone_ids = var.private_endpoint_properties.private_dns_zone_ids
   }
 
   private_service_connection = {
-    name                           = "${var.name}-private-endpoint-connection"
+    name                           = "${var.name}-pep-connection"
     private_connection_resource_id = azurerm_container_registry.acr.id
     subresource_names              = ["registry"]
     is_manual_connection           = var.private_endpoint_properties.private_service_connection_is_manual

--- a/infrastructure/modules/event-grid-topic/main.tf
+++ b/infrastructure/modules/event-grid-topic/main.tf
@@ -28,18 +28,18 @@ module "private_endpoint_eventgrid" {
 
   source = "../private-endpoint"
 
-  name                = "${var.topic_name}-azure-eventgrid-private-endpoint"
+  name                = "${var.topic_name}-azure-eventgrid-pep"
   resource_group_name = var.private_endpoint_properties.private_endpoint_resource_group_name
   location            = var.location
   subnet_id           = var.private_endpoint_properties.private_endpoint_subnet_id
 
   private_dns_zone_group = {
-    name                 = "${var.topic_name}-private-endpoint-zone-group"
+    name                 = "${var.topic_name}-pep-zone-group"
     private_dns_zone_ids = var.private_endpoint_properties.private_dns_zone_ids
   }
 
   private_service_connection = {
-    name                           = "${var.topic_name}-private-endpoint-connection"
+    name                           = "${var.topic_name}-pep-connection"
     private_connection_resource_id = azurerm_eventgrid_topic.azurerm_eventgrid.id
     subresource_names              = ["topic"]
     is_manual_connection           = var.private_endpoint_properties.private_service_connection_is_manual

--- a/infrastructure/modules/event-hub/main.tf
+++ b/infrastructure/modules/event-hub/main.tf
@@ -73,18 +73,18 @@ module "private_endpoint_eventhub" {
 
   source = "../private-endpoint"
 
-  name                = "${var.name}-azure-eventhub-private-endpoint"
+  name                = "${var.name}-azure-eventhub-pep"
   resource_group_name = var.private_endpoint_properties.private_endpoint_resource_group_name
   location            = var.location
   subnet_id           = var.private_endpoint_properties.private_endpoint_subnet_id
 
   private_dns_zone_group = {
-    name                 = "${var.name}-azure-eventhub-private-endpoint-zone-group"
+    name                 = "${var.name}-azure-eventhub-pep-zone-group"
     private_dns_zone_ids = var.private_endpoint_properties.private_dns_zone_ids_eventhub
   }
 
   private_service_connection = {
-    name                           = "${var.name}-eventhub-private-endpoint-connection"
+    name                           = "${var.name}-eventhub-pep-connection"
     private_connection_resource_id = azurerm_eventhub_namespace.eventhub_ns.id
     subresource_names              = ["namespace"]
     is_manual_connection           = var.private_endpoint_properties.private_service_connection_is_manual

--- a/infrastructure/modules/function-app/main.tf
+++ b/infrastructure/modules/function-app/main.tf
@@ -91,18 +91,18 @@ module "private_endpoint" {
 
   source = "../private-endpoint"
 
-  name                = "${var.function_app_name}-private-endpoint"
+  name                = "${var.function_app_name}-pep"
   resource_group_name = var.private_endpoint_properties.private_endpoint_resource_group_name
   location            = var.location
   subnet_id           = var.private_endpoint_properties.private_endpoint_subnet_id
 
   private_dns_zone_group = {
-    name                 = "${var.function_app_name}-private-endpoint-zone-group"
+    name                 = "${var.function_app_name}-pep-zone-group"
     private_dns_zone_ids = var.private_endpoint_properties.private_dns_zone_ids
   }
 
   private_service_connection = {
-    name                           = "${var.function_app_name}-private-endpoint-connection"
+    name                           = "${var.function_app_name}-pep-connection"
     private_connection_resource_id = azurerm_linux_function_app.function_app.id
     subresource_names              = ["sites"]
     is_manual_connection           = var.private_endpoint_properties.private_service_connection_is_manual

--- a/infrastructure/modules/key-vault/main.tf
+++ b/infrastructure/modules/key-vault/main.tf
@@ -28,18 +28,18 @@ module "private_endpoint_keyvault" {
 
   source = "../private-endpoint"
 
-  name                = "${var.name}-azure-keyvault-private-endpoint"
+  name                = "${var.name}-azure-keyvault-pep"
   resource_group_name = var.private_endpoint_properties.private_endpoint_resource_group_name
   location            = var.location
   subnet_id           = var.private_endpoint_properties.private_endpoint_subnet_id
 
   private_dns_zone_group = {
-    name                 = "${var.name}-azure-keyvault-private-endpoint-zone-group"
+    name                 = "${var.name}-azure-keyvault-pep-zone-group"
     private_dns_zone_ids = var.private_endpoint_properties.private_dns_zone_ids_keyvault
   }
 
   private_service_connection = {
-    name                           = "${var.name}-keyvault-private-endpoint-connection"
+    name                           = "${var.name}-keyvault-pep-connection"
     private_connection_resource_id = azurerm_key_vault.keyvault.id
     subresource_names              = ["vault"]
     is_manual_connection           = var.private_endpoint_properties.private_service_connection_is_manual

--- a/infrastructure/modules/linux-web-app/main.tf
+++ b/infrastructure/modules/linux-web-app/main.tf
@@ -120,18 +120,18 @@ module "private_endpoint" {
 
   source = "../private-endpoint"
 
-  name                = "${var.linux_web_app_name}-private-endpoint"
+  name                = "${var.linux_web_app_name}-pep"
   resource_group_name = var.private_endpoint_properties.private_endpoint_resource_group_name
   location            = var.location
   subnet_id           = var.private_endpoint_properties.private_endpoint_subnet_id
 
   private_dns_zone_group = {
-    name                 = "${var.linux_web_app_name}-private-endpoint-zone-group"
+    name                 = "${var.linux_web_app_name}-pep-zone-group"
     private_dns_zone_ids = var.private_endpoint_properties.private_dns_zone_ids
   }
 
   private_service_connection = {
-    name                           = "${var.linux_web_app_name}-private-endpoint-connection"
+    name                           = "${var.linux_web_app_name}-pep-connection"
     private_connection_resource_id = azurerm_linux_web_app.this.id
     subresource_names              = ["sites"]
     is_manual_connection           = var.private_endpoint_properties.private_service_connection_is_manual

--- a/infrastructure/modules/postgresql-flexible/main.tf
+++ b/infrastructure/modules/postgresql-flexible/main.tf
@@ -103,18 +103,18 @@ module "private_endpoint_postgresql_flexible_server" {
 
   source = "../private-endpoint"
 
-  name                = "${var.name}-postgresql-private-endpoint"
+  name                = "${var.name}-postgresql-pep"
   resource_group_name = var.private_endpoint_properties.private_endpoint_resource_group_name
   location            = var.location
   subnet_id           = var.private_endpoint_properties.private_endpoint_subnet_id
 
   private_dns_zone_group = {
-    name                 = "${var.name}-postgresql-private-endpoint-zone-group"
+    name                 = "${var.name}-postgresql-pep-zone-group"
     private_dns_zone_ids = var.private_endpoint_properties.private_dns_zone_ids_postgresql
   }
 
   private_service_connection = {
-    name                           = "${var.name}-postgresql-private-endpoint-connection"
+    name                           = "${var.name}-postgresql-pep-connection"
     private_connection_resource_id = azurerm_postgresql_flexible_server.postgresql_flexible_server.id
     subresource_names              = ["postgresqlServer"]
     is_manual_connection           = var.private_endpoint_properties.private_service_connection_is_manual

--- a/infrastructure/modules/service-bus/main.tf
+++ b/infrastructure/modules/service-bus/main.tf
@@ -42,18 +42,18 @@ module "private_endpoint_service_bus_namespace" {
 
   source = "../private-endpoint"
 
-  name                = "${var.servicebus_namespace_name}-servicebus-private-endpoint"
+  name                = "${var.servicebus_namespace_name}-servicebus-pep"
   resource_group_name = var.private_endpoint_properties.private_endpoint_resource_group_name
   location            = var.location
   subnet_id           = var.private_endpoint_properties.private_endpoint_subnet_id
 
   private_dns_zone_group = {
-    name                 = "${var.servicebus_namespace_name}-private-endpoint-zone-group"
+    name                 = "${var.servicebus_namespace_name}-pep-zone-group"
     private_dns_zone_ids = var.private_endpoint_properties.private_dns_zone_ids
   }
 
   private_service_connection = {
-    name                           = "${var.servicebus_namespace_name}-private-endpoint-connection"
+    name                           = "${var.servicebus_namespace_name}-pep-connection"
     private_connection_resource_id = azurerm_servicebus_namespace.this.id
     subresource_names              = ["namespace"]
     is_manual_connection           = var.private_endpoint_properties.private_service_connection_is_manual

--- a/infrastructure/modules/sql-server/main.tf
+++ b/infrastructure/modules/sql-server/main.tf
@@ -51,18 +51,18 @@ module "private_endpoint_sql_server" {
 
   source = "../private-endpoint"
 
-  name                = "${var.name}-sql-private-endpoint"
+  name                = "${var.name}-sql-pep"
   resource_group_name = var.private_endpoint_properties.private_endpoint_resource_group_name
   location            = var.location
   subnet_id           = var.private_endpoint_properties.private_endpoint_subnet_id
 
   private_dns_zone_group = {
-    name                 = "${var.name}-sql-private-endpoint-zone-group"
+    name                 = "${var.name}-sql-pep-zone-group"
     private_dns_zone_ids = var.private_endpoint_properties.private_dns_zone_ids_sql
   }
 
   private_service_connection = {
-    name                           = "${var.name}-sql-private-endpoint-connection"
+    name                           = "${var.name}-sql-pep-connection"
     private_connection_resource_id = azurerm_mssql_server.azure_sql_server.id
     subresource_names              = ["sqlServer"]
     is_manual_connection           = var.private_endpoint_properties.private_service_connection_is_manual

--- a/infrastructure/modules/storage/main.tf
+++ b/infrastructure/modules/storage/main.tf
@@ -47,18 +47,18 @@ module "private_endpoint_blob_storage" {
 
   source = "../private-endpoint"
 
-  name                = "${var.name}-blob-private-endpoint"
+  name                = "${var.name}-blob-pep"
   resource_group_name = var.private_endpoint_properties.private_endpoint_resource_group_name
   location            = var.location
   subnet_id           = var.private_endpoint_properties.private_endpoint_subnet_id
 
   private_dns_zone_group = {
-    name                 = "${var.name}-blob-private-endpoint-zone-group"
+    name                 = "${var.name}-blob-pep-zone-group"
     private_dns_zone_ids = var.private_endpoint_properties.private_dns_zone_ids_blob
   }
 
   private_service_connection = {
-    name                           = "${var.name}-blob-private-endpoint-connection"
+    name                           = "${var.name}-blob-pep-connection"
     private_connection_resource_id = azurerm_storage_account.storage_account.id
     subresource_names              = ["blob"]
     is_manual_connection           = var.private_endpoint_properties.private_service_connection_is_manual
@@ -72,18 +72,18 @@ module "private_endpoint_table_storage" {
 
   source = "../private-endpoint"
 
-  name                = "${var.name}-table-private-endpoint"
+  name                = "${var.name}-table-pep"
   resource_group_name = var.private_endpoint_properties.private_endpoint_resource_group_name
   location            = var.location
   subnet_id           = var.private_endpoint_properties.private_endpoint_subnet_id
 
   private_dns_zone_group = {
-    name                 = "${var.name}-table-private-endpoint-zone-group"
+    name                 = "${var.name}-table-pep-zone-group"
     private_dns_zone_ids = var.private_endpoint_properties.private_dns_zone_ids_table
   }
 
   private_service_connection = {
-    name                           = "${var.name}-table-private-endpoint-connection"
+    name                           = "${var.name}-table-pep-connection"
     private_connection_resource_id = azurerm_storage_account.storage_account.id
     subresource_names              = ["table"]
     is_manual_connection           = var.private_endpoint_properties.private_service_connection_is_manual
@@ -97,18 +97,18 @@ module "private_endpoint_queue_storage" {
 
   source = "../private-endpoint"
 
-  name                = "${var.name}-queue-private-endpoint"
+  name                = "${var.name}-queue-pep"
   resource_group_name = var.private_endpoint_properties.private_endpoint_resource_group_name
   location            = var.location
   subnet_id           = var.private_endpoint_properties.private_endpoint_subnet_id
 
   private_dns_zone_group = {
-    name                 = "${var.name}-queue-private-endpoint-zone-group"
+    name                 = "${var.name}-queue-pep-zone-group"
     private_dns_zone_ids = var.private_endpoint_properties.private_dns_zone_ids_queue
   }
 
   private_service_connection = {
-    name                           = "${var.name}-queue-private-endpoint-connection"
+    name                           = "${var.name}-queue-pep-connection"
     private_connection_resource_id = azurerm_storage_account.storage_account.id
     subresource_names              = ["queue"]
     is_manual_connection           = var.private_endpoint_properties.private_service_connection_is_manual


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

This PR deals with an issue related to long suffix names for `private endpoints`. When Azure appends a random name of an attached NIC private endpoint resources, the current templates code also appends "private-endpoints". Together with the auto-generated Azure NIC name, Terraform validation fails because _some_ resource names could exceed **80 characters**.

An example taken from a Terraform plan output,

```yaml
  - custom_dns_configs [] -> null
  ...
  - name = "KV-COHMAN-SBMJ-UKS-azure-keyvault-private-endpoint" -> null
  - network_interface = [
    - {
        - id   = ".../KV-COHMAN-SBMJ-UKS-azure-keyvault-private-en.nic.200686c4-0bfc-45eb-aa1a-3c7634fd3360"
        - name = "KV-COHMAN-SBMJ-UKS-azure-keyvault-private-en.nic.200686c4-0bfc-45eb-aa1a-3c7634fd3360"
    },
  ] -> null
  ...
```

#### Notable Changes
This PR updates the suffix `private-endpoint` to `pep` allowing more characters for user-names.

#### Caution
This PR will create *downtime* to update any existing private endpoints. 

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
