### PR TITLE
[DTOSS-9700] Update DNS record validation

### DIFF
--- a/infrastructure/modules/dns-a-record/variables.tf
+++ b/infrastructure/modules/dns-a-record/variables.tf
@@ -2,8 +2,8 @@ variable "name" {
   description = "The name of the DNS A Record service."
   type        = string
   validation {
-    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9-_]{0,253}[a-zA-Z0-9]$", var.name))
-    error_message = "The DNS A Record service name must be between 1 and 255 characters and can only contain alphanumeric characters, hyphens, and underscores."
+    condition     = can(regex("^[[:alnum:]*](?:[[:alnum:]-._]{0,61}[[:alnum:]])?$", var.name))
+    error_message = "The DNS A Record name must be up to 63 characters, start with an alphanumeric character or *, end with an alphanumeric character, and can contain alphanumeric characters, dots, hyphens and underscores."
   }
 }
 

--- a/infrastructure/modules/private-dns-a-record/variables.tf
+++ b/infrastructure/modules/private-dns-a-record/variables.tf
@@ -2,8 +2,8 @@ variable "name" {
   description = "The name of the Private DNS A Record."
   type        = string
   validation {
-    condition     = can(regex("^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$", var.name))
-    error_message = "The Private DNS A Record name must be up to 63 characters, start and end with an alphanumeric character, and can contain alphanumeric characters and hyphens."
+    condition     = can(regex("^[[:alnum:]*](?:[[:alnum:]-.]{0,61}[[:alnum:]])?$", var.name))
+    error_message = "The Private DNS A Record name must be up to 63 characters, start with an alphanumeric character or *, end with an alphanumeric character, and can contain alphanumeric characters, dots and hyphens."
   }
 }
 


### PR DESCRIPTION
## Description
The previous regular expression were too restrictive. Updates:
- Allow . in the body to separate subdomains
- Allow * at the start for wildcard domains
- Use [:alnum:] for readability
- Allow _ in public records

Tested with manage breast screening private records

## Context
Failure in manage breast screening after https://github.com/NHSDigital/dtos-devops-templates/pull/144

## Type of changes
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
