### PR TITLE
[DTOSS-9699] Set default value for workload_profile

### DIFF
--- a/infrastructure/modules/container-app-environment/tfdocs.md
+++ b/infrastructure/modules/container-app-environment/tfdocs.md
@@ -28,21 +28,6 @@ Description: ID of the subnet for the container app environment. Must be at leas
 
 Type: `string`
 
-### <a name="input_workload_profile"></a> [workload\_profile](#input\_workload\_profile)
-
-Description: Workload profile for the container app environment. This defines the scaling and resource allocation for the environment. Possible workload\_profile\_type values include Consumption, D4, D8, D16, D32, E4, E8, E16 and E32.
-
-Type:
-
-```hcl
-object({
-    name                  = optional(string, "Consumption")
-    workload_profile_type = optional(string, "Consumption")
-    minimum_count         = optional(number, 0)
-    maximum_count         = optional(number, 1)
-  })
-```
-
 ## Optional Inputs
 
 The following input variables are optional (have default values):
@@ -62,6 +47,23 @@ Description: Name of the hub resource group where the private DNS zone is locate
 Type: `string`
 
 Default: `null`
+
+### <a name="input_workload_profile"></a> [workload\_profile](#input\_workload\_profile)
+
+Description: Workload profile for the container app environment. This defines the scaling and resource allocation for the environment. Possible workload\_profile\_type values include Consumption, D4, D8, D16, D32, E4, E8, E16 and E32.
+
+Type:
+
+```hcl
+object({
+    name                  = optional(string, "Consumption")
+    workload_profile_type = optional(string, "Consumption")
+    minimum_count         = optional(number, 0)
+    maximum_count         = optional(number, 1)
+  })
+```
+
+Default: `{}`
 
 ### <a name="input_zone_redundancy_enabled"></a> [zone\_redundancy\_enabled](#input\_zone\_redundancy\_enabled)
 

--- a/infrastructure/modules/container-app-environment/variables.tf
+++ b/infrastructure/modules/container-app-environment/variables.tf
@@ -38,6 +38,7 @@ variable "workload_profile" {
     maximum_count         = optional(number, 1)
   })
   description = "Workload profile for the container app environment. This defines the scaling and resource allocation for the environment. Possible workload_profile_type values include Consumption, D4, D8, D16, D32, E4, E8, E16 and E32."
+  default     = {}
 }
 
 variable "zone_redundancy_enabled" {


### PR DESCRIPTION
## Description
The caller does not have to specify the value and the individual default values in the object are used
Tested successfully with Manage breast screening

## Context
Error in Manage breast screening where workload_profile is not set:
```
│ Error: Missing required argument
│
│   on main.tf line 57, in module "container-app-environment":
│   57: module "container-app-environment" {
│
│ The argument "workload_profile" is required, but no definition was found.
```

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
