### PR TITLE
fix: only rebuild images when there is a change to the app code

### DIFF
--- a/.github/workflows/stage-3-build-images.yaml
+++ b/.github/workflows/stage-3-build-images.yaml
@@ -32,7 +32,7 @@ on:
         description: Build all images (true) or only changed ones (false)
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   get-functions:
@@ -63,7 +63,7 @@ jobs:
           COMPOSE_FILES_CSV: ${{ inputs.docker_compose_file }}
           EXCLUDED_CONTAINERS_CSV: ${{ inputs.excluded_containers_csv_list }}
           SOURCE_CODE_PATH: ${{ inputs.function_app_source_code_path }}
-          MANUAL_BUILD_ALL: ${{ inputs.build_all_images || true }}
+          MANUAL_BUILD_ALL: ${{ inputs.build_all_images || false }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash ./templates/scripts/deployments/get-docker-names.sh
 

--- a/scripts/deployments/get-docker-names.sh
+++ b/scripts/deployments/get-docker-names.sh
@@ -112,28 +112,10 @@ for compose_file in ${COMPOSE_FILES_CSV}; do
         done
     elif [[ ${#source_changes[@]} -eq 0 ]]; then
         echo "No files changed."
-    elif [[ "${source_changes[*],,}" =~ shared ]]; then
-        echo "Shared folder changed, building all images."
+    else
+        echo "Application change detected, building all images."
         for key in "${!docker_services_map[@]}"; do
             changed_services+=("${docker_services_map[$key]}")
-        done
-    else
-        echo "Checking changed folders..."
-        for folder in "${source_changes[@]}"; do
-            matched="false"
-            for function_path in "${!docker_services_map[@]}"; do
-                # The changed folder may be a deeper path than the Function path, so it must be matched this way around
-                if [[ "${folder}" =~ ${function_path} ]]; then
-                    changed_services+=("${docker_services_map[$function_path]}")
-                    echo "  - ${folder} matches service '${docker_services_map[$function_path]}'"
-                    matched="true"
-                    remove_from_array "${folder}" source_changes
-                    remove_from_array "${folder}" non_matched_changes # In case it's in this array from a previous compose file iteration
-                    continue
-                fi
-            done
-            # Collect changed folders that were not matched to services
-            [[ "${matched}" == "false" ]] && non_matched_changes+=("${folder}")
         done
     fi
     echo


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

The image rebuild process for all functions should only run when there is a change in the application directory.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
