### PR TITLE
fix: RBAC role assignments re-applied every tf plan

### DIFF
--- a/infrastructure/modules/rbac-assignment/main.tf
+++ b/infrastructure/modules/rbac-assignment/main.tf
@@ -2,12 +2,6 @@
 resource "azurerm_role_assignment" "role_assignment" {
   scope                            = var.scope
   principal_id                     = var.principal_id
-  role_definition_id               = data.azurerm_role_definition.role_definition.id
+  role_definition_name             = var.role_definition_name
   skip_service_principal_aad_check = var.skip_service_principal_aad_check
-}
-
-# Look up the role definition by name within the correct subscription
-data "azurerm_role_definition" "role_definition" {
-  name  = var.role_definition_name
-  scope = regex("^(/subscriptions/[^/]+)", var.scope)[0]
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This change prevents RBAC Role Assignments from being re-deployed every single Terraform plan.

- Linked to: https://github.com/NHSDigital/dtos-cohort-manager/pull/1435

## Context

RBAC Role Assignments were being applied specifying a `role_definition_id` which was being resolved by a terraform data query. From azurerm provider version 3.67.0 it has been possible to directly specify `role_definition_name` instead, which is a variable we already have. Since the `scope` is defined as a separate parameter already, this Role Definition will continue to be resolved in the correct susbcription.

Without the dynamic data query, the plan result is predictable (and no longer a case of 'known after apply'), resulting in a stable Terraform state.

## Testing
- Plan demonstrating the RBAC Role Assignments issue for [Prod Core](https://dev.azure.com/nhse-dtos/dtos-cohort-manager/_build/results?buildId=24412&view=results)
- Successful terraform plan for [Prod Core(no RBAC changes)](https://dev.azure.com/nhse-dtos/dtos-cohort-manager/_build/results?buildId=24437&view=results)
- Successful terraform plan for [Prod Audit (no RBAC changes)](https://dev.azure.com/nhse-dtos/dtos-cohort-manager/_build/results?buildId=24477&view=results)
- Successful terraform plan for [Dev Hub (no RBAC changes)](https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=24478&view=results)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
