### PR TITLE
Add `event_trigger_config` block to container app job module

### DIFF
--- a/infrastructure/modules/container-app-job/README.md
+++ b/infrastructure/modules/container-app-job/README.md
@@ -47,3 +47,50 @@ module "container-app-job" {
 }
 ```
 
+Add cron expression trigger for the container app job:
+```hcl
+module "container-app-job" {
+
+  source = "../../../dtos-devops-templates/infrastructure/modules/container-app-job"
+
+  name                         = "ca-workload-name-${var.environment}"
+  resource_group_name          = var.resource_group_name
+  location                     = var.location
+  container_app_environment_id = module.container-app-environment.id
+
+  schedule_trigger_config {
+    cron_expression          = var.cron_expression
+    parallelism              = var.job_parallelism
+    replica_completion_count = var.replica_completion_count
+  }
+
+  ...
+}
+```
+
+Add event source trigger for the container app job:
+```hcl
+module "container-app-job" {
+
+  source = "../../../dtos-devops-templates/infrastructure/modules/container-app-job"
+
+  name                         = "ca-workload-name-${var.environment}"
+  resource_group_name          = var.resource_group_name
+  location                     = var.location
+  container_app_environment_id = module.container-app-environment.id
+
+  event_trigger_config {
+    parallelism              = var.job_parallelism
+    replica_completion_count = var.replica_completion_count
+    scale {
+      polling_interval_in_seconds = var.polling_interval_in_seconds
+      rules {
+        custom_rule_type = var.scale_rule_type
+        metadata         = var.scale_rule_metadata
+      }
+    }
+  }
+
+  ...
+}
+```

--- a/infrastructure/modules/container-app-job/tfdocs.md
+++ b/infrastructure/modules/container-app-job/tfdocs.md
@@ -104,6 +104,14 @@ Type: `number`
 
 Default: `"0.5"`
 
+### <a name="input_polling_interval_in_seconds"></a> [polling\_interval\_in\_seconds](#input\_polling\_interval\_in\_seconds)
+
+Description: Interval to check each event source in seconds.
+
+Type: `number`
+
+Default: `300`
+
 ### <a name="input_replica_completion_count"></a> [replica\_completion\_count](#input\_replica\_completion\_count)
 
 Description: The number of replicas that must complete successfully for the job to be considered successful.
@@ -127,6 +135,22 @@ Description: The timeout in seconds for a replica to complete execution.
 Type: `number`
 
 Default: `300`
+
+### <a name="input_scale_rule_metadata"></a> [scale\_rule\_metadata](#input\_scale\_rule\_metadata)
+
+Description: Metadata properties to describe the scale rule. Refer to [KEDA scaler documentation](https://keda.sh/docs/2.17/scalers/) for metadata relevant to the scale rule.
+
+Type: `map(string)`
+
+Default: `{}`
+
+### <a name="input_scale_rule_type"></a> [scale\_rule\_type](#input\_scale\_rule\_type)
+
+Description: Type of scale rule for the event trigger. See [KEDA scaler documentation](https://keda.sh/docs/2.17/scalers/) for supported types.
+
+Type: `string`
+
+Default: `null`
 
 ### <a name="input_user_assigned_identity_ids"></a> [user\_assigned\_identity\_ids](#input\_user\_assigned\_identity\_ids)
 

--- a/infrastructure/modules/container-app-job/variables.tf
+++ b/infrastructure/modules/container-app-job/variables.tf
@@ -72,6 +72,12 @@ variable "memory" {
   default     = "0.5"
 }
 
+variable "polling_interval_in_seconds" {
+  description = "Interval to check each event source in seconds."
+  type        = number
+  default     = 300
+}
+
 variable "replica_completion_count" {
   description = "The number of replicas that must complete successfully for the job to be considered successful."
   type        = number
@@ -90,6 +96,18 @@ variable "replica_retry_limit" {
   default     = 3
 }
 
+variable "scale_rule_metadata" {
+  description = "Metadata properties to describe the scale rule. Refer to [KEDA scaler documentation](https://keda.sh/docs/2.17/scalers/) for metadata relevant to the scale rule."
+  type        = map(string)
+  default     = {}
+}
+
+variable "scale_rule_type" {
+  description = "Type of scale rule for the event trigger. See [KEDA scaler documentation](https://keda.sh/docs/2.17/scalers/) for supported types."
+  type        = string
+  default     = null
+}
+
 variable "user_assigned_identity_ids" {
   description = "List of user assigned identity IDs to assign to the container app."
   type        = list(string)
@@ -104,6 +122,7 @@ variable "workload_profile_name" {
 }
 
 locals {
-  memory = "${var.memory}Gi"
-  cpu    = var.memory / 2
+  memory          = "${var.memory}Gi"
+  cpu             = var.memory / 2
+  scale_rule_name = "${var.name}-event-trigger-${var.scale_rule_type}"
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR introduces an `event_trigger_config block` to the container app job module.
Makes the default event trigger scaler `azure-queue` as this is the initial use case.

See https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_app_job#event_trigger_config-1

<!-- Describe your changes in detail. -->

## Context

Container app jobs can be configured to be triggered by events from a variety of event sources eg. Azure Storage Queue.
Terraform supports configuration of container app jobs via the `event_trigger_config` block.

The current use case is triggering a container app job from an Azure Storage Queue (for Breast Screening Private Beta) but there are other scalers that can be defined by the `scale_rule_type` var  (see https://keda.sh/docs/2.9/scalers/)


<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
