### PR TITLE
Feat/dtoss 10668 amend postgresql flexible terraform module to parameterise prevent destroy lifecycle

### DIFF
--- a/infrastructure/modules/postgresql-flexible/database.tf
+++ b/infrastructure/modules/postgresql-flexible/database.tf
@@ -9,4 +9,10 @@ resource "azurerm_postgresql_flexible_server_database" "postgresql_flexible_db" 
   lifecycle {
     prevent_destroy = false
   }
+
+  # Ensure admins are destroyed before databases
+  depends_on = [
+    azurerm_postgresql_flexible_server_active_directory_administrator.postgresql_admin,
+    azurerm_postgresql_flexible_server_active_directory_administrator.admin_identity
+  ]
 }

--- a/infrastructure/modules/postgresql-flexible/database.tf
+++ b/infrastructure/modules/postgresql-flexible/database.tf
@@ -10,6 +10,10 @@ resource "azurerm_postgresql_flexible_server_database" "postgresql_flexible_db" 
     prevent_destroy = false
   }
 
+  timeouts {
+    delete = "60m"
+  }
+
   # Ensure admins are destroyed before databases
   depends_on = [
     azurerm_postgresql_flexible_server_active_directory_administrator.postgresql_admin,

--- a/infrastructure/modules/postgresql-flexible/main.tf
+++ b/infrastructure/modules/postgresql-flexible/main.tf
@@ -69,6 +69,10 @@ resource "azurerm_postgresql_flexible_server_active_directory_administrator" "po
   object_id           = var.postgresql_admin_object_id
   principal_name      = var.postgresql_admin_principal_name
   principal_type      = var.postgresql_admin_principal_type
+
+  timeouts {
+    delete = "60m"
+  }
 }
 
 resource "azurerm_postgresql_flexible_server_active_directory_administrator" "admin_identity" {
@@ -83,6 +87,10 @@ resource "azurerm_postgresql_flexible_server_active_directory_administrator" "ad
   principal_name      = each.value.principal_name
   object_id           = each.value.object_id
   principal_type      = "ServicePrincipal"
+
+  timeouts {
+    delete = "60m"
+  }
 }
 
 # Create the server configurations


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

We’re currently facing an issue with purging the PostgreSQL database in the manbrs project. While this is not a complete fix, the changes help mitigate the timeout problem we've been encountering.
Some of the child resources have a default timeout of less than 30 minutes, which is insufficient for deletion in certain cases.
Please note that there is an open issue tracking this problem

https://github.com/hashicorp/terraform-provider-azurerm/issues/24736

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
