### PR TITLE
fix: removing the deprecated enabled value for diagnostic settings metrics

### DIFF
--- a/infrastructure/modules/api-management/main.tf
+++ b/infrastructure/modules/api-management/main.tf
@@ -153,6 +153,5 @@ module "diagnostic-settings" {
   log_analytics_workspace_id = var.log_analytics_workspace_id
   enabled_log                = var.monitor_diagnostic_setting_apim_enabled_logs
   enabled_metric             = var.monitor_diagnostic_setting_apim_metrics
-  metric_enabled             = var.metric_enabled
 
 }

--- a/infrastructure/modules/cdn-frontdoor-profile/main.tf
+++ b/infrastructure/modules/cdn-frontdoor-profile/main.tf
@@ -40,6 +40,5 @@ module "diagnostic-settings" {
   log_analytics_workspace_id = var.log_analytics_workspace_id
   enabled_log                = var.monitor_diagnostic_setting_frontdoor_enabled_logs
   enabled_metric             = var.monitor_diagnostic_setting_frontdoor_metrics
-  metric_enabled             = var.metric_enabled
 
 }

--- a/infrastructure/modules/cdn-frontdoor-profile/variables.tf
+++ b/infrastructure/modules/cdn-frontdoor-profile/variables.tf
@@ -19,12 +19,6 @@ variable "log_analytics_workspace_id" {
   default     = null
 }
 
-variable "metric_enabled" {
-  type        = bool
-  description = "Enables retention for diagnostic settings metric"
-  default     = true
-}
-
 variable "monitor_diagnostic_setting_frontdoor_enabled_logs" {
   type        = list(string)
   description = "Controls which logs will be enabled for the Front Door profile"

--- a/infrastructure/modules/key-vault/main.tf
+++ b/infrastructure/modules/key-vault/main.tf
@@ -60,7 +60,6 @@ module "diagnostic-settings" {
   log_analytics_workspace_id = var.log_analytics_workspace_id
   enabled_log                = var.monitor_diagnostic_setting_keyvault_enabled_logs
   enabled_metric             = var.monitor_diagnostic_setting_keyvault_metrics
-  metric_enabled             = var.metric_enabled
 }
 
 data "azurerm_client_config" "current" {}

--- a/infrastructure/modules/key-vault/variables.tf
+++ b/infrastructure/modules/key-vault/variables.tf
@@ -19,12 +19,6 @@ variable "log_analytics_workspace_id" {
   description = "id of the log analytics workspace to send resource logging to via diagnostic settings"
 }
 
-variable "metric_enabled" {
-  type        = bool
-  description = "to enable retention for diagnostic settings metric"
-  default     = true
-}
-
 variable "monitor_diagnostic_setting_keyvault_enabled_logs" {
   type        = list(string)
   description = "Controls what logs will be enabled for the keyvault"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

A change to the implementation of the Diagnostic Setting module required to eliminate the deprecated form of metric definition.

Old implementation:
```
module "diagnostic-settings" {
  source = "../diagnostic-settings"

  name                       = "${var.name}-diagnostic-setting"
  target_resource_id         = azurerm_api_management.apim.id
  log_analytics_workspace_id = var.log_analytics_workspace_id
  enabled_log                = var.monitor_diagnostic_setting_apim_enabled_logs
  metric                     = var.monitor_diagnostic_setting_apim_metrics
  metric_enabled             = var.metric_enabled
}
```

New implementation:
```
module "diagnostic-settings" {

  source = "../diagnostic-settings"

  name                       = "${var.name}-diagnostic-setting"
  target_resource_id         = azurerm_api_management.apim.id
  log_analytics_workspace_id = var.log_analytics_workspace_id
  enabled_log                = var.monitor_diagnostic_setting_apim_enabled_logs
  enabled_metric             = var.monitor_diagnostic_setting_apim_metrics
}
```


## Context

This change requires making modifications to all the repositories using this module! 
An example of needed changes can be found in the Cohort-Manager repo: [PR-1543](https://github.com/NHSDigital/dtos-cohort-manager/pull/1543)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
