### PR TITLE
Feat/dtoss 10700 use a docker image for the postgres database for the review apps

### DIFF
--- a/infrastructure/modules/container-app-job/variables.tf
+++ b/infrastructure/modules/container-app-job/variables.tf
@@ -76,6 +76,12 @@ variable "environment_variables" {
   default     = {}
 }
 
+variable "secret_variables" {
+  description = "Secret environment variables to pass to the container app."
+  type        = map(string)
+  default     = {}
+}
+
 variable "job_parallelism" {
   description = "The number of replicas that can run in parallel."
   type        = number

--- a/infrastructure/modules/container-app/output.tf
+++ b/infrastructure/modules/container-app/output.tf
@@ -7,3 +7,7 @@ output "url" {
   description = "URL of the container app. Only available if is_web_app is true."
   value       = var.is_web_app ? "https://${azurerm_container_app.main.ingress[0].fqdn}" : ""
 }
+
+output "container_app_fqdn" {
+  value = azurerm_container_app.main.latest_revision_fqdn
+}

--- a/infrastructure/modules/container-app/variables.tf
+++ b/infrastructure/modules/container-app/variables.tf
@@ -52,7 +52,13 @@ variable "docker_image" {
 }
 
 variable "environment_variables" {
-  description = "Environment variables to pass to the container app. Only non-secret variables. Secrets must be stored in key vault 'app_key_vault_id'"
+  description = "Environment variables to pass to the container app. Only non-secret variables. Secrets can be stored in key vault 'app_key_vault_id'"
+  type        = map(string)
+  default     = {}
+}
+
+variable "secret_variables" {
+  description = "Secret environment variables to pass to the container app."
   type        = map(string)
   default     = {}
 }
@@ -69,8 +75,14 @@ variable "is_web_app" {
   default     = false
 }
 
-variable "http_port" {
-  description = "HTTP port for the web app. Default is 8080."
+variable "is_tcp_app" {
+  description = "Is this a TCP app? If true, ingress is enabled."
+  type        = bool
+  default     = false
+}
+
+variable "port" {
+  description = "Port for the ingress. Default is 8080."
   type        = number
   default     = 8080
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Small changes to how the postgres database is deployed for review apps. Essentially you can now allow a postgres database be deployed in a container app. If you do this you also need to modify the ingress to allow TCP communication so that other Azure services can communicate with it. 

Here you can see that it has been successfully deployed: - 

https://dev.azure.com/nhse-dtos/dtos-manage-breast-screening/_build/results?buildId=26435&view=logs&j=4a575bb6-72e3-5024-4059-681dfff5b130

Also allows secrets to be stored within the container app and container app job. 

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
