### PR TITLE
[DTOS-1073] Implement app secrets in container app jobs

### DIFF
--- a/infrastructure/modules/container-app-job/README.md
+++ b/infrastructure/modules/container-app-job/README.md
@@ -47,3 +47,26 @@ module "container-app-job" {
 }
 ```
 
+## Key vault secrets
+The container app job can be mapped to Azure Key Vaults for secret management:
+
+- **App Key Vault:**
+  - All secrets from the app key vault are fetched and mapped to secret environment variables if `fetch_secrets_from_app_key_vault = true` and `app_key_vault_id` is provided.
+  - Secret names in Key Vault must use hyphens (e.g., `SECRET-KEY`). These are mapped to environment variables with underscores (e.g., `SECRET_KEY`).
+  - Secrets are updated when Terraform runs, or automatically within 30 minutes.
+
+**Warning:** The module cannot read from a key vault if it doesn't exist yet. Recommended workflow:
+1. Create the key vault(s) using the [key-vault module](../key-vault/).
+2. Deploy the container app with `fetch_secrets_from_app_key_vault = false` (default) and/or `enable_auth = false`.
+3. Manually add the required secrets to the key vault(s).
+4. Set `fetch_secrets_from_app_key_vault = true` and/or `enable_auth = true`, then re-run Terraform to populate the app with secret environment variables and enable authentication.
+
+Example (app secrets):
+```hcl
+module "job" {
+  source                           = "../../../modules/dtos-devops-templates/infrastructure/modules/container-app-job"
+  ...
+  app_key_vault_id                 = module.app-key-vault.key_vault_id
+  fetch_secrets_from_app_key_vault = true
+}
+```

--- a/infrastructure/modules/container-app-job/data.tf
+++ b/infrastructure/modules/container-app-job/data.tf
@@ -1,0 +1,6 @@
+data "azurerm_key_vault_secrets" "app" {
+  count      = var.fetch_secrets_from_app_key_vault ? 1 : 0
+  depends_on = [module.key_vault_reader_role_app]
+
+  key_vault_id = var.app_key_vault_id
+}

--- a/infrastructure/modules/container-app-job/main.tf
+++ b/infrastructure/modules/container-app-job/main.tf
@@ -2,8 +2,26 @@
 locals {
   all_identity_ids = compact(concat(
     [var.acr_managed_identity_id],
-    var.user_assigned_identity_ids)
-  )
+    var.user_assigned_identity_ids,
+    [module.container_app_identity.id]
+  ))
+}
+
+module "container_app_identity" {
+  source              = "../managed-identity"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  uai_name            = "mi-${var.name}"
+}
+
+module "key_vault_reader_role_app" {
+  count = var.fetch_secrets_from_app_key_vault ? 1 : 0
+
+  source = "../rbac-assignment"
+
+  scope                = var.app_key_vault_id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = module.container_app_identity.principal_id
 }
 
 resource "azurerm_container_app_job" "this" {
@@ -19,6 +37,19 @@ resource "azurerm_container_app_job" "this" {
   identity {
     type         = "UserAssigned"
     identity_ids = local.all_identity_ids
+  }
+
+  dynamic "secret" {
+
+    for_each = var.fetch_secrets_from_app_key_vault ? data.azurerm_key_vault_secrets.app[0].secrets : []
+
+    content {
+      # KV secrets are uppercase and hyphen separated
+      # app container secrets are lowercase and hyphen separated
+      name                = lower(secret.value.name)
+      identity            = module.container_app_identity.id
+      key_vault_secret_id = secret.value.id
+    }
   }
 
   # Configure manual trigger for on-demand execution via CLI
@@ -59,6 +90,16 @@ resource "azurerm_container_app_job" "this" {
         content {
           name  = env.key
           value = env.value
+        }
+      }
+      dynamic "env" {
+        for_each = var.fetch_secrets_from_app_key_vault ? data.azurerm_key_vault_secrets.app[0].secrets : []
+        content {
+          # Env vars are uppercase and underscore separated
+          name = upper(replace(env.value.name, "-", "_"))
+          # KV secrets are uppercase and hyphen separated
+          # app container secrets are lowercase and hyphen separated
+          secret_name = lower(env.value.name)
         }
       }
     }

--- a/infrastructure/modules/container-app-job/tfdocs.md
+++ b/infrastructure/modules/container-app-job/tfdocs.md
@@ -48,6 +48,14 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_app_key_vault_id"></a> [app\_key\_vault\_id](#input\_app\_key\_vault\_id)
+
+Description: ID of the key vault to store app secrets. Each secret is mapped to an environment variable. Required when fetch\_secrets\_from\_app\_key\_vault is true.
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_container_args"></a> [container\_args](#input\_container\_args)
 
 Description: The arguments to pass to the container command. Optional.
@@ -79,6 +87,16 @@ Description: Environment variables to pass to the container app. Only non-secret
 Type: `map(string)`
 
 Default: `{}`
+
+### <a name="input_fetch_secrets_from_app_key_vault"></a> [fetch\_secrets\_from\_app\_key\_vault](#input\_fetch\_secrets\_from\_app\_key\_vault)
+
+Description:     Fetch secrets from the app key vault and map them to secret environment variables. Requires app\_key\_vault\_id.
+
+    WARNING: The key vault must be created by terraform and populated manually before setting this to true.
+
+Type: `bool`
+
+Default: `false`
 
 ### <a name="input_job_parallelism"></a> [job\_parallelism](#input\_job\_parallelism)
 
@@ -143,10 +161,25 @@ Description: Workload profile in this container app environment
 Type: `string`
 
 Default: `"Consumption"`
+## Modules
 
+The following Modules are called:
+
+### <a name="module_container_app_identity"></a> [container\_app\_identity](#module\_container\_app\_identity)
+
+Source: ../managed-identity
+
+Version:
+
+### <a name="module_key_vault_reader_role_app"></a> [key\_vault\_reader\_role\_app](#module\_key\_vault\_reader\_role\_app)
+
+Source: ../rbac-assignment
+
+Version:
 
 ## Resources
 
 The following resources are used by this module:
 
 - [azurerm_container_app_job.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_app_job) (resource)
+- [azurerm_key_vault_secrets.app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secrets) (data source)

--- a/infrastructure/modules/container-app-job/variables.tf
+++ b/infrastructure/modules/container-app-job/variables.tf
@@ -8,6 +8,22 @@ variable "resource_group_name" {
   type        = string
 }
 
+variable "app_key_vault_id" {
+  description = "ID of the key vault to store app secrets. Each secret is mapped to an environment variable. Required when fetch_secrets_from_app_key_vault is true."
+  type        = string
+  default     = null
+}
+variable "fetch_secrets_from_app_key_vault" {
+  description = <<EOT
+    Fetch secrets from the app key vault and map them to secret environment variables. Requires app_key_vault_id.
+
+    WARNING: The key vault must be created by terraform and populated manually before setting this to true.
+    EOT
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
 variable "location" {
   type        = string
   description = "The location/region where the container app environment is created."

--- a/infrastructure/modules/container-app/main.tf
+++ b/infrastructure/modules/container-app/main.tf
@@ -30,7 +30,7 @@ module "key_vault_reader_role_infra" {
 locals {
   all_identity_ids = compact(concat(
     [var.acr_managed_identity_id],
-    var.user_assigned_identity_ids,
+
     [module.container_app_identity.id]
   ))
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Set application secrets as environment variables on the container app job
This is the same technique as used in the container app module

## Context
Required for jobs to connect to Notify etc

## Review
https://github.com/NHSDigital/dtos-manage-breast-screening/pull/350 is used for testing

Check `SECRET-KEY` which is defined in the app key vault creates the corresponding `SECRET_KEY` on the job container

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
