### PR TITLE
feat: add the option to enable HTTP/2 option for function apps

### DIFF
--- a/infrastructure/modules/function-app/main.tf
+++ b/infrastructure/modules/function-app/main.tf
@@ -32,11 +32,11 @@ resource "azurerm_linux_function_app" "function_app" {
     container_registry_managed_identity_client_id = var.acr_mi_client_id
     ftps_state                                    = var.ftps_state
     minimum_tls_version                           = var.minimum_tls_version
+    http2_enabled                                 = var.http2_enabled
     health_check_path                             = var.health_check_path
     health_check_eviction_time_in_min = var.health_check_path == null ? null : (
       var.health_check_eviction_time_in_min == null ? 10 : var.health_check_eviction_time_in_min
     )
-
     app_service_logs {
       disk_quota_mb         = var.app_service_logs_disk_quota_mb
       retention_period_days = var.app_service_logs_retention_period_days

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -176,6 +176,12 @@ variable "minimum_tls_version" {
   }
 }
 
+variable "http2_enabled" {
+  type        = bool
+  description = "Specifies whether or not the HTTP2 protocol should be enabled. Defaults to false"
+  default     = false
+}
+
 variable "monitor_diagnostic_setting_function_app_enabled_logs" {
   type        = list(string)
   description = "Controls what logs will be enabled for the function app"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adding the `http2_enabled` configuration option for Function Apps to enable the `HTTP/2`.
Currently set to `false` by default. After a successful implementation in the non-live environments, the default value can be changed to `true`. 

Major benefits of implementing `HTTP/2` are:
- improved performance, 
- enhanced security,
- reduced latency

## Context

More information on the `HTTP/2` itself available [here](https://azure.microsoft.com/en-us/blog/announcing-http-2-support-in-azure-app-service/).
A quick TL;DR:

```
HTTP/2 is a rework of how HTTP semantics flow over TCP connections, and HTTP/2 support is present in Windows 10 and Windows Server 2016. 
HTTP/2 is a major upgrade after nearly two decades of HTTP/1.1 use and reduces the impact of latency and connection load on web servers.

The major advance of HTTP/1.1 was the use of persistent connections to service multiple requests in a row. In HTTP/2, a persistent connection can be used to service multiple simultaneous requests.
In the process, HTTP/2 introduces several additional features that improve the efficiency of HTTP over the network.
```

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
