### PR TITLE
fix: DTOSS-10994 Deploy the CAE with a different custom_infra_rg_name value per CAE instance

### DIFF
--- a/infrastructure/modules/container-app-environment/main.tf
+++ b/infrastructure/modules/container-app-environment/main.tf
@@ -6,7 +6,8 @@ resource "azurerm_container_app_environment" "main" {
   infrastructure_subnet_id           = var.vnet_integration_subnet_id
   internal_load_balancer_enabled     = true
   zone_redundancy_enabled            = var.zone_redundancy_enabled
-  infrastructure_resource_group_name = "${var.resource_group_name}-cae-infra"
+  infrastructure_resource_group_name = var.custom_infra_rg_name != null ? var.custom_infra_rg_name : "${var.resource_group_name}-cae-infra"
+
   workload_profile {
     name                  = var.workload_profile.name
     workload_profile_type = var.workload_profile.workload_profile_type

--- a/infrastructure/modules/container-app-environment/variables.tf
+++ b/infrastructure/modules/container-app-environment/variables.tf
@@ -47,6 +47,12 @@ variable "zone_redundancy_enabled" {
   default     = false
 }
 
+variable "custom_infra_rg_name" {
+  type        = string
+  description = "Set the custom name for the infrastructure_resource_group_name variable per each CAE. "
+  default     = null
+}
+
 locals {
   dns_record = replace(
     azurerm_container_app_environment.main.default_domain,


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

In order to be able to deploy multiple Container App Environments in the same subscription, we need to have a way of creating a different `custom_infra_rg_name` value per the instance of the CAE.

This PR enables that possibility by implementing the `custom_infra_rg_name` variable. If implemented on the client side, the module will use it during the deployment.
If it's not being parsed by the client repository (as it is right now), it will use the current `"${var.resource_group_name}-cae-infra"` option by default (**no breaking change**).

## Context

The example of a plan **without** the `custom_infra_rg_name` specified by the client repository (no changes):
https://dev.azure.com/nhse-dtos/dtos-cohort-manager/_build/results?buildId=27345&view=logs&j=2e61fdd4-29ab-51b4-3516-655c0df6fcf2&t=430e7011-249c-5e1a-31f4-0c3babbc029d

The example of a plan **with** the `custom_infra_rg_name` defined by the client repository:
https://dev.azure.com/nhse-dtos/dtos-cohort-manager/_build/results?buildId=27344&view=logs&j=2e61fdd4-29ab-51b4-3516-655c0df6fcf2&t=430e7011-249c-5e1a-31f4-0c3babbc029d

<img width="1762" height="385" alt="image" src="https://github.com/user-attachments/assets/4518aab7-14fb-4eea-acc6-7f46e1b3d993" />


## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
