### PR TITLE
[DTOSS-11034] fix: improve queue creation timing with private endpoint dependency

### DIFF
--- a/infrastructure/modules/storage/main.tf
+++ b/infrastructure/modules/storage/main.tf
@@ -28,6 +28,8 @@ resource "azurerm_storage_container" "container" {
   name                  = each.value.container_name
   storage_account_id    = azurerm_storage_account.storage_account.id
   container_access_type = each.value.container_access_type
+
+  depends_on = [module.private_endpoint_blob_storage]
 }
 
 resource "azurerm_storage_queue" "queue" {
@@ -35,6 +37,8 @@ resource "azurerm_storage_queue" "queue" {
 
   name                 = each.value
   storage_account_name = azurerm_storage_account.storage_account.name
+
+  depends_on = [module.private_endpoint_queue_storage]
 }
 
 


### PR DESCRIPTION
## Description

Add explicit dependency declarations to ensure storage containers and queues are created after their respective private endpoints are fully established.

**Changes:**
- Add `depends_on = [module.private_endpoint_blob_storage]` to storage container resource
- Add `depends_on = [module.private_endpoint_queue_storage]` to storage queue resource
- Ensures private endpoint network configuration completes before storage resource operations

## Context

**Problem:** Intermittent 403 authorisation errors occur during `terraform apply` when creating storage queues and containers with private endpoints enabled. The error suggests network connectivity issues rather than permissions problems.

**Root Cause:** Storage containers and queues were being created in parallel with private endpoint configuration. Without explicit dependencies, Terraform could attempt to validate these resources before private endpoint DNS propagation and network connectivity were fully established.

**Solution:** Add explicit `depends_on` declarations to ensure storage resources wait for their corresponding private endpoints to complete before creation/validation.

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
