### PR TITLE
DTOSS-11103: Spike Azure monitor infrastructure metrics

### DIFF
--- a/infrastructure/modules/postgresql-flexible/alerts.tf
+++ b/infrastructure/modules/postgresql-flexible/alerts.tf
@@ -1,0 +1,86 @@
+resource "azurerm_monitor_metric_alert" "memory" {
+  count = var.enable_monitoring ? 1 : 0
+
+  name                = "${azurerm_postgresql_flexible_server.postgresql_flexible_server.name}-memory"
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_postgresql_flexible_server.postgresql_flexible_server.id]
+  description         = "Action will be triggered when memory use is greater than ${var.alert_memory_threshold}%"
+  window_size         = var.alert_window_size
+  frequency           = local.alert_frequency
+
+  criteria {
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metric_name      = "memory_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.alert_memory_threshold
+  }
+
+  action {
+    action_group_id = var.action_group_id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "cpu" {
+  count = var.enable_monitoring ? 1 : 0
+
+  name                = "${azurerm_postgresql_flexible_server.postgresql_flexible_server.name}-cpu"
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_postgresql_flexible_server.postgresql_flexible_server.id]
+  description         = "Action will be triggered when cpu use is greater than ${var.azure_cpu_threshold}%"
+  window_size         = var.alert_window_size
+  frequency           = local.alert_frequency
+
+  criteria {
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metric_name      = "cpu_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.azure_cpu_threshold
+  }
+
+  action {
+    action_group_id = var.action_group_id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "storage" {
+  count = var.enable_monitoring ? 1 : 0
+
+  name                = "${azurerm_postgresql_flexible_server.postgresql_flexible_server.name}-storage"
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_postgresql_flexible_server.postgresql_flexible_server.id]
+  description         = "Action will be triggered when storage use is greater than ${var.azure_storage_threshold}%"
+  window_size         = var.alert_window_size
+  frequency           = local.alert_frequency
+
+  criteria {
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metric_name      = "storage_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.azure_storage_threshold
+  }
+
+  action {
+    action_group_id = var.action_group_id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}

--- a/infrastructure/modules/postgresql-flexible/variables.tf
+++ b/infrastructure/modules/postgresql-flexible/variables.tf
@@ -193,3 +193,54 @@ variable "monitor_diagnostic_setting_postgresql_server_metrics" {
   type        = list(string)
   description = "Controls what metrics will be enabled for the sql server"
 }
+
+variable "alert_window_size" {
+  type     = string
+  nullable = false
+  default  = "PT5M"
+  validation {
+    condition     = contains(["PT1M", "PT5M", "PT15M", "PT30M", "PT1H", "PT6H", "PT12H"], var.alert_window_size)
+    error_message = "The alert_window_size must be one of: PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H"
+  }
+  description = "The period of time that is used to monitor alert activity e.g. PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H. The interval between checks is adjusted accordingly."
+}
+
+variable "enable_monitoring" {
+  description = "Whether monitoring and alerting is enabled for the PostgreSQL Flexible Server."
+  type        = bool
+}
+
+variable "action_group_id" {
+  type        = string
+  description = "ID of the action group to notify."
+}
+
+variable "alert_memory_threshold" {
+  type    = number
+  description = "If alerting is enabled this will control what the memory threshold will be, default will be 80."
+  default = 80
+}
+
+variable "azure_storage_threshold" {
+  type    = number
+  description = "If alerting is enabled this will control what the storage threshold will be, default will be 80."
+  default = 80
+}
+
+variable "azure_cpu_threshold" {
+  type        = number
+  description = "If alerting is enabled this will control what the cpu threshold will be, default will be 80."
+  default     = 80
+}
+
+locals {
+  alert_frequency_map = {
+    PT5M  = "PT1M"
+    PT15M = "PT1M"
+    PT30M = "PT1M"
+    PT1H  = "PT1M"
+    PT6H  = "PT5M"
+    PT12H = "PT5M"
+  }
+  alert_frequency = local.alert_frequency_map[var.alert_window_size]
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adding alerts for the postgres database, have tested on the manbrs project via the review app environment. 

I modified the memory alert so the threshold was a lot lower and was able to trigger it via running the container app db job. 

<img width="1767" height="791" alt="image" src="https://github.com/user-attachments/assets/bc9a0cfb-eb36-4fce-80a6-cca3bf65a629" />

I reduced the trigger to 65.6 for memory : - 
<img width="1732" height="783" alt="image" src="https://github.com/user-attachments/assets/0a5d32d7-328d-480f-ac95-a3c42a9a3866" />

I reduced the trigger to 11 for CPU: - 
<img width="1714" height="836" alt="image" src="https://github.com/user-attachments/assets/d0e1aac9-6957-4bb0-8f37-b123979f7d34" />

I reduced the trigger to 8 for the storage: - 

<img width="1674" height="858" alt="image" src="https://github.com/user-attachments/assets/123ae34e-f3a9-4ab9-a0a0-1d5c0d75e4a5" />

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
