### PR TITLE
DTOSS-11103: Put defaults on postgres variables

### DIFF
--- a/infrastructure/modules/postgresql-flexible/variables.tf
+++ b/infrastructure/modules/postgresql-flexible/variables.tf
@@ -208,11 +208,13 @@ variable "alert_window_size" {
 variable "enable_monitoring" {
   description = "Whether monitoring and alerting is enabled for the PostgreSQL Flexible Server."
   type        = bool
+  default     = false
 }
 
 variable "action_group_id" {
   type        = string
   description = "ID of the action group to notify."
+  default     = null
 }
 
 variable "alert_memory_threshold" {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Seeing some TF deploy errors on Manage relating to devops templates changes, is there a corresponding Manage PR? We're missing postgres values for enable_monitoring and action_group_id and these don't have defaults
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/04e181eb-0e97-4161-8862-8f9c45cba7d7" />

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
