### PR TITLE
Add in additional permissions for the AVD to deploy

### DIFF
--- a/infrastructure/modules/virtual-desktop/main.tf
+++ b/infrastructure/modules/virtual-desktop/main.tf
@@ -58,6 +58,14 @@ resource "azurerm_virtual_desktop_workspace_application_group_association" "this
   workspace_id         = azurerm_virtual_desktop_workspace.this.id
 }
 
+resource "azurerm_role_assignment" "avd_autoscale_hostpool" {
+  count = var.principal_id == null ? 0 : 1
+
+  scope                = azurerm_virtual_desktop_host_pool.this.id
+  role_definition_name = "Desktop Virtualization Power On Off Contributor"
+  principal_id         = var.principal_id
+}
+
 resource "azurerm_role_assignment" "rg_users" {
   scope                = var.resource_group_id
   role_definition_name = "Virtual Machine User Login"

--- a/infrastructure/modules/virtual-desktop/variables.tf
+++ b/infrastructure/modules/virtual-desktop/variables.tf
@@ -187,3 +187,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "principal_id" {
+  description = "The principal (object) ID to assign the 'Desktop Virtualization Power On Off Contributor' role to the host pool. If null, the role assignment will not be created. This maintains backward compatibility for existing deployments. The role is required for autoscaling but can be omitted if autoscaling is not used or the role is assigned manually."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION


<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Have to add role assignment "Desktop Virtualization Power On Off Contributor" to allow AVD to deploy in the Lung project.

Include the principal (object) ID to assign the 'Desktop Virtualization Power On Off Contributor' role to the host pool. If null, the role assignment will not be created. This maintains backward compatibility for existing deployments. The role is required for autoscaling but can be omitted if autoscaling is not used or the role is assigned manually.

https://dev.azure.com/nhse-dtos/lung-cancer-screening/_build/results?buildId=35873&view=logs&j=c970d263-77bb-52d7-1861-5b2637d7126d&t=c970d263-77bb-52d7-1861-5b2637d7126d

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
