### PR TITLE
feat(iac): DTOSS-12657 support disabling public access for app-insights

### DIFF
--- a/infrastructure/modules/app-insights/main.tf
+++ b/infrastructure/modules/app-insights/main.tf
@@ -7,5 +7,8 @@ resource "azurerm_application_insights" "appins" {
   workspace_id        = var.log_analytics_workspace_id
   application_type    = var.appinsights_type
 
+  internet_ingestion_enabled = var.internet_ingestion_enabled
+  internet_query_enabled     = var.internet_query_enabled
+
   tags = var.tags
 }

--- a/infrastructure/modules/app-insights/variables.tf
+++ b/infrastructure/modules/app-insights/variables.tf
@@ -57,6 +57,18 @@ variable "action_group_id" {
   default     = null
 }
 
+variable "internet_ingestion_enabled" {
+  type        = bool
+  description = "Whether public internet ingestion is enabled for Application Insights."
+  default     = true
+}
+
+variable "internet_query_enabled" {
+  type        = bool
+  description = "Whether public internet querying is enabled for Application Insights."
+  default     = true
+}
+
 locals {
   alert_window_size = var.alert_frequency
 }


### PR DESCRIPTION

## Description

This PR adds two new variables to the `app-insights` module: `internet_ingestion_enabled` and `internet_query_enabled`. These variables are mapped to the corresponding properties in the `azurerm_application_insights` resource.

- `internet_ingestion_enabled`: Controls whether public internet ingestion is allowed for Application Insights.
- `internet_query_enabled`: Controls whether public internet querying is allowed for Application Insights.

## Context

To enhance the security posture of our infrastructure, we need the ability to disable public access to Application Insights when it is accessed through Private Link (AMPLS). This change allows projects using this module to enforce private-only access.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
