### PR TITLE
Remove a section to make slack alerts more concise

### DIFF
--- a/infrastructure/modules/logic-app-slack-alert/main.tf
+++ b/infrastructure/modules/logic-app-slack-alert/main.tf
@@ -72,30 +72,9 @@ resource "azurerm_logic_app_action_custom" "post_to_slack" {
               "type": "header",
               "text": {
                 "type": "plain_text",
-                "text": "@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), concat('✅ Resolved – ', triggerBody()?['data']?['essentials']?['alertRule']), concat('🚨 Alert – ', triggerBody()?['data']?['essentials']?['alertRule']))}",
+                "text": "@{concat(if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), concat('✅ ', triggerBody()?['data']?['essentials']?['severity'], ' resolved'), concat('🚨 ', triggerBody()?['data']?['essentials']?['severity'], ' alert')), ' – ', triggerBody()?['data']?['essentials']?['alertRule'], if(empty(coalesce(triggerBody()?['data']?['essentials']?['configurationItems']?[0], '')), '', concat(' (resource: `', triggerBody()?['data']?['essentials']?['configurationItems']?[0], '`)')))}",
                 "emoji": true
               }
-            },
-            {
-              "type": "section",
-              "fields": [
-                {
-                  "type": "mrkdwn",
-                  "text": "@{concat('*Severity*\n', triggerBody()?['data']?['essentials']?['severity'])}"
-                },
-                {
-                  "type": "mrkdwn",
-                  "text": "@{concat('*Status*\n', triggerBody()?['data']?['essentials']?['monitorCondition'])}"
-                },
-                {
-                  "type": "mrkdwn",
-                  "text": "@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), concat('*Resolved At*\n', triggerBody()?['data']?['essentials']?['resolvedDateTime']), concat('*Fired At*\n', triggerBody()?['data']?['essentials']?['firedDateTime']))}"
-                },
-                {
-                  "type": "mrkdwn",
-                  "text": "@{concat('*Resource*\n`', coalesce(triggerBody()?['data']?['essentials']?['configurationItems']?[0], 'N/A'), '`')}"
-                }
-              ]
             },
             {
               "type": "section",


### PR DESCRIPTION


<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This change moves the resource and severity fields into the heading, so it will look something like:

✅ Sev1 resolved – appi-preprod-uks-manbrs-exceptions-alert (resource: appi-preprod-uks-manbrs)

It also drops the fields for Status and Resolved at, since the heading already contains whether it is resolved or not, and we have the time the slack message was received at as a proxy for alert times.

Otherwise I've tried to keep all the same sources of information. I did wonder though if we can replace appi-preprod-uks-manbrs-exceptions-alert with a human readable alert name? If we do that maybe the resource part is not neccessary.

We could also maybe hide the description if the alert is resolved, as in that case you only need enough info to identify what's been resolved.

## Context

The current alerts take up a lot of vertical space in slack, which means they tend to drown out other messages in the channel and limit the number of messages visible at once.

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
