### PR TITLE
feat: [DTOSS-12154] provide a functionality to enable or disable shared access key

### DIFF
--- a/infrastructure/modules/storage/main.tf
+++ b/infrastructure/modules/storage/main.tf
@@ -8,6 +8,7 @@ resource "azurerm_storage_account" "storage_account" {
   account_tier                  = var.account_tier
   public_network_access_enabled = var.public_network_access_enabled
   access_tier                   = var.access_tier
+  shared_access_key_enabled     = var.shared_access_key_enabled
 
   tags = var.tags
 
@@ -177,7 +178,7 @@ module "diagnostic-settings-sa-resource" {
   source = "../diagnostic-settings"
 
   name                       = "${azurerm_storage_account.storage_account.name}-diagnotic-setting-storage-account"
-  target_resource_id         = "${azurerm_storage_account.storage_account.id}"
+  target_resource_id         = azurerm_storage_account.storage_account.id
   log_analytics_workspace_id = var.log_analytics_workspace_id
   enabled_metric             = var.monitor_diagnostic_setting_storage_account_resource_metrics
 

--- a/infrastructure/modules/storage/tfdocs.md
+++ b/infrastructure/modules/storage/tfdocs.md
@@ -129,9 +129,25 @@ Type: `number`
 
 Default: `99`
 
+### <a name="input_blob_properties_change_feed_enabled"></a> [blob\_properties\_change\_feed\_enabled](#input\_blob\_properties\_change\_feed\_enabled)
+
+Description: Is the blob service properties for change feed events enabled? Required for Point-in-Time Restore.
+
+Type: `bool`
+
+Default: `false`
+
 ### <a name="input_blob_properties_delete_retention_policy"></a> [blob\_properties\_delete\_retention\_policy](#input\_blob\_properties\_delete\_retention\_policy)
 
 Description: The value set for blob properties delete retention policy.
+
+Type: `number`
+
+Default: `null`
+
+### <a name="input_blob_properties_restore_policy_days"></a> [blob\_properties\_restore\_policy\_days](#input\_blob\_properties\_restore\_policy\_days)
+
+Description: Specifies the number of days that the blob can be restored. Set to null to disable by default. Note: Must be less than blob and container delete retention policy days.
 
 Type: `number`
 
@@ -144,6 +160,14 @@ Description: To enable versioning for blob.
 Type: `bool`
 
 Default: `false`
+
+### <a name="input_container_delete_retention_policy_days"></a> [container\_delete\_retention\_policy\_days](#input\_container\_delete\_retention\_policy\_days)
+
+Description: Specifies the number of days that the container should be retained. Defaulting to 7 for baseline data protection.
+
+Type: `number`
+
+Default: `7`
 
 ### <a name="input_enable_alerting"></a> [enable\_alerting](#input\_enable\_alerting)
 
@@ -198,6 +222,22 @@ Description: List of RBAC roles to assign to the Storage Account.
 Type: `list(string)`
 
 Default: `[]`
+
+### <a name="input_share_properties_retention_policy_days"></a> [share\_properties\_retention\_policy\_days](#input\_share\_properties\_retention\_policy\_days)
+
+Description: Specifies the number of days that the file share should be retained. Set to null to disable by default, or provide a number to enable.
+
+Type: `number`
+
+Default: `null`
+
+### <a name="input_shared_access_key_enabled"></a> [shared\_access\_key\_enabled](#input\_shared\_access\_key\_enabled)
+
+Description: Enables or disables Shared Key authorization for the storage account, defaults will be true.
+
+Type: `bool`
+
+Default: `true`
 
 ### <a name="input_storage_account_service"></a> [storage\_account\_service](#input\_storage\_account\_service)
 

--- a/infrastructure/modules/storage/variables.tf
+++ b/infrastructure/modules/storage/variables.tf
@@ -213,6 +213,12 @@ variable "share_properties_retention_policy_days" {
   default     = null
 }
 
+variable "shared_access_key_enabled" {
+  type        = bool
+  description = "Enables or disables Shared Key authorization for the storage account, defaults will be true."
+  default     = true
+}
+
 locals {
   alert_frequency_map = {
     PT5M  = "PT1M"


### PR DESCRIPTION
## Description

This PR introduces a new configuration option to enable or disable Shared Access Key authentication for the Storage module.

## Context

Some environments require disabling Shared Access Key access in favour of identity-based authentication. Providing this capability improves security posture and aligns the module with best practices and organizational policies.

### Changes

- Added a new module input to control Shared Access Key access.
- When enabled, storage accounts allow Shared Access Key authentication.
- When disabled, Shared Access Key authentication is explicitly turned off.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
