### PR TITLE
feat: [DTOSS-12476] added support for storage account object replication

### DIFF
--- a/infrastructure/modules/storage/main.tf
+++ b/infrastructure/modules/storage/main.tf
@@ -80,6 +80,25 @@ resource "azurerm_storage_queue" "queue" {
   depends_on = [module.private_endpoint_queue_storage]
 }
 
+resource "azurerm_storage_object_replication" "object_replication" {
+  for_each = local.containers_with_replication
+
+  source_storage_account_id      = azurerm_storage_account.storage_account.id
+  destination_storage_account_id = each.value.object_replication.destination_storage_account_id
+
+  rules {
+    source_container_name      = each.value.object_replication.source_container_name
+    destination_container_name = each.value.object_replication.destination_container_name
+  }
+}
+
+locals {
+  containers_with_replication = {
+    for key, container in var.containers :
+    key => container
+    if container.object_replication != null
+  }
+}
 
 /* --------------------------------------------------------------------------------------------------
   Private Endpoint Configuration

--- a/infrastructure/modules/storage/tfdocs.md
+++ b/infrastructure/modules/storage/tfdocs.md
@@ -6,7 +6,7 @@ The following input variables are required:
 
 ### <a name="input_containers"></a> [containers](#input\_containers)
 
-Description: Definition of Storage Containers configuration, including optional immutability policy settings.
+Description: Definition of Storage Containers configuration, including optional immutability policy and object replication settings.
 
 Type:
 
@@ -20,6 +20,11 @@ map(object({
       protected_append_writes_all_enabled = optional(bool, false)
       protected_append_writes_enabled     = optional(bool, false)
     }))
+    object_replication = optional(object({
+      source_container_name          = string
+      destination_storage_account_id = string
+      destination_container_name     = string
+    }), null)
   }))
 ```
 
@@ -347,5 +352,6 @@ The following resources are used by this module:
 - [azurerm_storage_account.storage_account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) (resource)
 - [azurerm_storage_container.container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) (resource)
 - [azurerm_storage_container_immutability_policy.policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container_immutability_policy) (resource)
+- [azurerm_storage_object_replication.object_replication](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_object_replication) (resource)
 - [azurerm_storage_queue.queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) (resource)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)

--- a/infrastructure/modules/storage/variables.tf
+++ b/infrastructure/modules/storage/variables.tf
@@ -54,7 +54,7 @@ variable "blob_properties_versioning_enabled" {
 }
 
 variable "containers" {
-  description = "Definition of Storage Containers configuration, including optional immutability policy settings."
+  description = "Definition of Storage Containers configuration, including optional immutability policy and object replication settings."
   type = map(object({
     container_name        = string
     container_access_type = string
@@ -64,6 +64,11 @@ variable "containers" {
       protected_append_writes_all_enabled = optional(bool, false)
       protected_append_writes_enabled     = optional(bool, false)
     }))
+    object_replication = optional(object({
+      source_container_name          = string
+      destination_storage_account_id = string
+      destination_container_name     = string
+    }), null)
   }))
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR adds support for Storage Account Object Replication configuration to the storage account module. The module now exposes object replication settings, allowing consumers to define and manage replication policies directly as part of the storage account deployment.

## Context

Object replication is required for scenarios where data needs to be asynchronously replicated between source and destination storage accounts for resiliency, compliance, or cross-region distribution. Previously, the storage account module did not provide a way to configure these settings, requiring manual or out‑of‑band configuration.
By adding object replication support, this change brings the module closer to feature parity with the underlying Azure Storage capabilities and reduces operational overhead.

## Changes Introduced

- Added object replication configuration support to the storage account module
- Exposed relevant inputs/variables for defining object replication rules
- Wired object replication settings into the storage account resource configuration
- Maintained backward compatibility for existing module consumers

## Evidence / Validation

- Existing storage account deployments remain unaffected when object replication is not configured
- Sample configuration tested with object replication enabled between source and destination storage accounts

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
