### PR TITLE
PPHA-925: Make GitHub storage container internal

### DIFF
--- a/infrastructure/modules/container-app-job/main.tf
+++ b/infrastructure/modules/container-app-job/main.tf
@@ -40,6 +40,26 @@ resource "azurerm_container_app_job" "this" {
   }
 
   dynamic "secret" {
+    for_each = var.ghcr_pat_secret_uri != null ? [1] : []
+
+    content {
+      name                = "ghcr-token"
+      key_vault_secret_id = var.ghcr_pat_secret_uri
+      identity            = module.container_app_identity.id
+    }
+  }
+
+  dynamic "registry" {
+    for_each = var.ghcr_pat_secret_uri != null ? [1] : []
+
+    content {
+      server               = "ghcr.io"
+      username             = var.ghcr_username
+      password_secret_name = "ghcr-token"
+    }
+  }
+
+  dynamic "secret" {
 
     for_each = var.fetch_secrets_from_app_key_vault ? data.azurerm_key_vault_secrets.app[0].secrets : []
 

--- a/infrastructure/modules/container-app-job/variables.tf
+++ b/infrastructure/modules/container-app-job/variables.tf
@@ -161,6 +161,18 @@ variable "time_window" {
   default     = 30
 }
 
+variable "ghcr_username" {
+  type        = string
+  description = ""
+  default = null
+}
+
+variable "ghcr_pat_secret_uri" {
+  type        = string
+  description = "URI of the GitHub Container Registry Personal Access Token stored in Key Vault. This is used to authenticate to GHCR if var.docker_image is hosted there. The secret must be in the format 'username:token'."
+  default = null
+}
+
 locals {
   memory = "${var.memory}Gi"
   cpu    = var.memory / 2

--- a/infrastructure/modules/container-app/main.tf
+++ b/infrastructure/modules/container-app/main.tf
@@ -62,6 +62,27 @@ resource "azurerm_container_app" "main" {
   }
 
   dynamic "secret" {
+    for_each = var.ghcr_pat_secret_uri != null ? [1] : []
+
+    content {
+      name                = "ghcr-token"
+      key_vault_secret_id = var.ghcr_pat_secret_uri
+      identity            = module.container_app_identity.id
+    }
+  }
+
+  dynamic "registry" {
+    for_each = var.ghcr_pat_secret_uri != null ? [1] : []
+
+    content {
+      server               = "ghcr.io"
+      username             = var.ghcr_username
+      password_secret_name = "ghcr-token"
+    }
+  }
+
+
+  dynamic "secret" {
     for_each = var.secret_variables
     content {
       name  = replace(lower(secret.key), "_", "-")

--- a/infrastructure/modules/container-app/variables.tf
+++ b/infrastructure/modules/container-app/variables.tf
@@ -202,6 +202,18 @@ variable "probe_path" {
   default     = null
 }
 
+variable "ghcr_username" {
+  type        = string
+  description = ""
+  default = null
+}
+
+variable "ghcr_pat_secret_uri" {
+  type        = string
+  description = "URI of the GitHub Container Registry Personal Access Token stored in Key Vault. This is used to authenticate to GHCR if var.docker_image is hosted there. The secret must be in the format 'username:token'."
+  default = null
+}
+
 locals {
   memory = "${var.memory}Gi"
   cpu    = var.memory / 2


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

We need Azure Container Apps to pull container images from a private GitHub Container Registry (GHCR) repository.
At present, GitHub Container Registry does not support authentication using Azure Managed Identity. Because of this, authentication must be handled using GitHub credentials, typically a username and Personal Access Token (PAT).
• The PAT would be stored securely as a secret
• Terraform would reference the secret during deployment
• Azure Container Apps would use the PAT to authenticate with GHCR

**User Dependency**

PAT tokens are generally associated with an individual GitHub user account.
If that user leaves the organisation, has their account disabled, loses the required permissions, or rotates their credentials, the token may become invalid and could impact deployments or running services.

**Secret Management Overhead**

Using PAT tokens also introduces additional operational responsibilities, including:
• Secure storage and rotation of secrets
• Token and credential lifecycle management
• Monitoring token expiry dates
• Manual renewal and maintenance processes

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
