### PR TITLE
PPHA-925: Convert the container registry to generic

### DIFF
--- a/infrastructure/modules/container-app-job/README.md
+++ b/infrastructure/modules/container-app-job/README.md
@@ -70,3 +70,25 @@ module "job" {
   fetch_secrets_from_app_key_vault = true
 }
 ```
+
+## Generic private registry authentication
+
+The module can authenticate to any private container registry by providing the registry server URL, username and a Key Vault secret URI containing the password. The module will create a container registry credential in the container app referencing the Key Vault secret for secure authentication.
+
+Example:
+```hcl
+module "container-app-job" {
+
+  source = "../../../dtos-devops-templates/infrastructure/modules/container-app-job"
+
+  name                         = "ca-workload-name-${var.environment}"
+  resource_group_name          = var.resource_group_name
+  location                     = var.location
+  container_app_environment_id = module.container-app-environment.id
+
+  container_registry_server     = "ghcr.io"
+  container_registry_username   = "github-username"
+  container_registry_secret_uri = module.app-key-vault.secrets["ghcr-token"].versionless_id
+
+}
+```

--- a/infrastructure/modules/container-app-job/main.tf
+++ b/infrastructure/modules/container-app-job/main.tf
@@ -40,22 +40,22 @@ resource "azurerm_container_app_job" "this" {
   }
 
   dynamic "secret" {
-    for_each = var.ghcr_pat_secret_uri != null ? [1] : []
+    for_each = var.container_registry_secret_uri != null ? [1] : []
 
     content {
-      name                = "ghcr-token"
-      key_vault_secret_id = var.ghcr_pat_secret_uri
+      name                = "password"
+      key_vault_secret_id = var.container_registry_secret_uri
       identity            = module.container_app_identity.id
     }
   }
 
   dynamic "registry" {
-    for_each = var.ghcr_pat_secret_uri != null ? [1] : []
+    for_each = var.container_registry_secret_uri != null ? [1] : []
 
     content {
-      server               = "ghcr.io"
-      username             = var.ghcr_username
-      password_secret_name = "ghcr-token"
+      server               = var.container_registry_server
+      username             = var.container_registry_username
+      password_secret_name = "password"
     }
   }
 

--- a/infrastructure/modules/container-app-job/tfdocs.md
+++ b/infrastructure/modules/container-app-job/tfdocs.md
@@ -88,6 +88,30 @@ Type: `list(string)`
 
 Default: `null`
 
+### <a name="input_container_registry_secret_uri"></a> [container\_registry\_secret\_uri](#input\_container\_registry\_secret\_uri)
+
+Description: Key Vault secret URI containing the registry password or token
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_container_registry_server"></a> [container\_registry\_server](#input\_container\_registry\_server)
+
+Description: Container registry hostname (for example ghcr.io)
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_container_registry_username"></a> [container\_registry\_username](#input\_container\_registry\_username)
+
+Description: Username used to authenticate to the container registry
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_cron_expression"></a> [cron\_expression](#input\_cron\_expression)
 
 Description: Cron formatted repeating schedule of a Cron Job eg. '0 5 * * *'. Optional.

--- a/infrastructure/modules/container-app-job/variables.tf
+++ b/infrastructure/modules/container-app-job/variables.tf
@@ -161,16 +161,22 @@ variable "time_window" {
   default     = 30
 }
 
-variable "ghcr_username" {
+variable "container_registry_server" {
   type        = string
-  description = ""
-  default = null
+  description = "Container registry hostname (for example ghcr.io)"
+  default     = null
 }
 
-variable "ghcr_pat_secret_uri" {
+variable "container_registry_username" {
   type        = string
-  description = "URI of the GitHub Container Registry Personal Access Token stored in Key Vault. This is used to authenticate to GHCR if var.docker_image is hosted there. The secret must be in the format 'username:token'."
-  default = null
+  description = "Username used to authenticate to the container registry"
+  default     = null
+}
+
+variable "container_registry_secret_uri" {
+  type        = string
+  description = "Key Vault secret URI containing the registry password or token"
+  default     = null
 }
 
 locals {

--- a/infrastructure/modules/container-app/README.md
+++ b/infrastructure/modules/container-app/README.md
@@ -153,3 +153,26 @@ We will allow using the previously pinned "4.34.0" or newer, as defined in the c
 New version definition is `version = ">= 4.34.0"`
 
 More on the provider version constraints in terraform modules can be found [here](https://developer.hashicorp.com/terraform/language/modules/develop/providers#provider-version-constraints-in-modules).
+
+
+## Generic private registry authentication
+
+The module can authenticate to any private container registry by providing the registry server URL, username and a Key Vault secret URI containing the password. The module will create a container registry credential in the container app referencing the Key Vault secret for secure authentication.
+
+Example:
+```hcl
+module "container-app" {
+
+  source = "../../../dtos-devops-templates/infrastructure/modules/container-app"
+
+  name                         = "ca-workload-name-${var.environment}"
+  resource_group_name          = var.resource_group_name
+  location                     = var.location
+  container_app_environment_id = module.container-app-environment.id
+
+  container_registry_server     = "ghcr.io"
+  container_registry_username   = "github-username"
+  container_registry_secret_uri = module.app-key-vault.secrets["ghcr-token"].versionless_id
+
+}
+```

--- a/infrastructure/modules/container-app/main.tf
+++ b/infrastructure/modules/container-app/main.tf
@@ -62,22 +62,22 @@ resource "azurerm_container_app" "main" {
   }
 
   dynamic "secret" {
-    for_each = var.ghcr_pat_secret_uri != null ? [1] : []
+    for_each = var.container_registry_secret_uri != null ? [1] : []
 
     content {
-      name                = "ghcr-token"
-      key_vault_secret_id = var.ghcr_pat_secret_uri
+      name                = "password"
+      key_vault_secret_id = var.container_registry_secret_uri
       identity            = module.container_app_identity.id
     }
   }
 
   dynamic "registry" {
-    for_each = var.ghcr_pat_secret_uri != null ? [1] : []
+    for_each = var.container_registry_secret_uri != null ? [1] : []
 
     content {
-      server               = "ghcr.io"
-      username             = var.ghcr_username
-      password_secret_name = "ghcr-token"
+      server               = var.container_registry_server
+      username             = var.container_registry_username
+      password_secret_name = "password"
     }
   }
 

--- a/infrastructure/modules/container-app/tfdocs.md
+++ b/infrastructure/modules/container-app/tfdocs.md
@@ -96,6 +96,30 @@ Type: `list(string)`
 
 Default: `[]`
 
+### <a name="input_container_registry_secret_uri"></a> [container\_registry\_secret\_uri](#input\_container\_registry\_secret\_uri)
+
+Description: Key Vault secret URI containing the registry password or token
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_container_registry_server"></a> [container\_registry\_server](#input\_container\_registry\_server)
+
+Description: Container registry hostname (for example ghcr.io)
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_container_registry_username"></a> [container\_registry\_username](#input\_container\_registry\_username)
+
+Description: Username used to authenticate to the container registry
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_enable_alerting"></a> [enable\_alerting](#input\_enable\_alerting)
 
 Description: Whether monitoring and alerting is enabled for the PostgreSQL Flexible Server.

--- a/infrastructure/modules/container-app/variables.tf
+++ b/infrastructure/modules/container-app/variables.tf
@@ -202,16 +202,22 @@ variable "probe_path" {
   default     = null
 }
 
-variable "ghcr_username" {
+variable "container_registry_server" {
   type        = string
-  description = ""
-  default = null
+  description = "Container registry hostname (for example ghcr.io)"
+  default     = null
 }
 
-variable "ghcr_pat_secret_uri" {
+variable "container_registry_username" {
   type        = string
-  description = "URI of the GitHub Container Registry Personal Access Token stored in Key Vault. This is used to authenticate to GHCR if var.docker_image is hosted there. The secret must be in the format 'username:token'."
-  default = null
+  description = "Username used to authenticate to the container registry"
+  default     = null
+}
+
+variable "container_registry_secret_uri" {
+  type        = string
+  description = "Key Vault secret URI containing the registry password or token"
+  default     = null
 }
 
 locals {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

We need Azure Container Apps to pull container images from a private GitHub Container Registry (GHCR) repository.
At present, GitHub Container Registry does not support authentication using Azure Managed Identity. Because of this, authentication must be handled using GitHub credentials, typically a username and Personal Access Token (PAT).
• The PAT would be stored securely as a secret
• Terraform would reference the secret during deployment
• Azure Container Apps would use the PAT to authenticate with GHCR

User Dependency

PAT tokens are generally associated with an individual GitHub user account.
If that user leaves the organisation, has their account disabled, loses the required permissions, or rotates their credentials, the token may become invalid and could impact deployments or running services.

Secret Management Overhead

Using PAT tokens also introduces additional operational responsibilities, including:
• Secure storage and rotation of secrets
• Token and credential lifecycle management
• Monitoring token expiry dates
• Manual renewal and maintenance processes

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
