### PR TITLE
fix: DTOSS-13146 native workspace dcr link Fix

### DIFF
--- a/infrastructure/modules/log-analytics-workspace/main.tf
+++ b/infrastructure/modules/log-analytics-workspace/main.tf
@@ -12,6 +12,13 @@ resource "azurerm_log_analytics_workspace" "log_analytics_workspace" {
   }
 
   tags = var.tags
+
+  # When data_collection_rule_id is managed externally (e.g. by azapi_update_resource
+  # to break a circular dependency with a workspace-transform DCR), changes to it
+  # must be ignored to prevent plan/apply churn.
+  lifecycle {
+    ignore_changes = [data_collection_rule_id]
+  }
 }
 
 /* --------------------------------------------------------------------------------------------------

--- a/infrastructure/modules/log-analytics-workspace/variables.tf
+++ b/infrastructure/modules/log-analytics-workspace/variables.tf
@@ -42,3 +42,9 @@ variable "monitor_diagnostic_setting_log_analytics_workspace_metrics" {
   type        = list(string)
   description = "Controls what metrics will be enabled for the Long Analytics Workspace"
 }
+
+variable "ignore_data_collection_rule_id" {
+  type        = bool
+  default     = false
+  description = "When true, ignores changes to data_collection_rule_id so it can be managed externally (e.g. by azapi_update_resource for workspace-transform DCRs)."
+}

--- a/infrastructure/modules/log-analytics-workspace/variables.tf
+++ b/infrastructure/modules/log-analytics-workspace/variables.tf
@@ -42,9 +42,3 @@ variable "monitor_diagnostic_setting_log_analytics_workspace_metrics" {
   type        = list(string)
   description = "Controls what metrics will be enabled for the Long Analytics Workspace"
 }
-
-variable "ignore_data_collection_rule_id" {
-  type        = bool
-  default     = false
-  description = "When true, ignores changes to data_collection_rule_id so it can be managed externally (e.g. by azapi_update_resource for workspace-transform DCRs)."
-}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

The Terraform configuration that links the Log Analytics Workspace (LAW) to the AppRequests workspace transform Data Collection Rule (DCR) has proven unreliable. Approximately one month ago the link silently disappeared with no corresponding deployment, and the existing Terraform code failed to detect or correct the drift.

## Context

we need fail safe way to insure that LAW and DCR are linked together to reliably filter the health check logs

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
