### PR TITLE
feat: add a static inbound option for the private dns resolver

### DIFF
--- a/infrastructure/modules/private-dns-zone-resolver/main.tf
+++ b/infrastructure/modules/private-dns-zone-resolver/main.tf
@@ -18,6 +18,7 @@ resource "azurerm_private_dns_resolver_inbound_endpoint" "private_dns_resolver_i
 
   ip_configurations {
     private_ip_allocation_method = var.inbound_endpoint_config.private_ip_allocation_method
+    private_ip_address           = var.inbound_endpoint_config.private_ip_allocation_method == "Static" ? var.inbound_endpoint_config.private_ip_address : null
     subnet_id                    = var.inbound_endpoint_config.subnet_id
   }
 }

--- a/infrastructure/modules/private-dns-zone-resolver/tfdocs.md
+++ b/infrastructure/modules/private-dns-zone-resolver/tfdocs.md
@@ -34,7 +34,7 @@ The following input variables are optional (have default values):
 
 ### <a name="input_inbound_endpoint_config"></a> [inbound\_endpoint\_config](#input\_inbound\_endpoint\_config)
 
-Description: The configuration for the inbound endpoint.
+Description: The configuration for the inbound endpoint. `private_ip_allocation_method` must be either `"Static"` or `"Dynamic"`. `private_ip_address` is optional but **required** when `private_ip_allocation_method` is set to `"Static"`.
 
 Type:
 
@@ -43,6 +43,7 @@ object({
     name                         = string
     private_ip_allocation_method = string
     subnet_id                    = string
+    private_ip_address           = optional(string, null)
   })
 ```
 
@@ -51,8 +52,9 @@ Default:
 ```json
 {
   "name": "",
-  "private_ip_allocation_method": "",
-  "subnet_id": ""
+  "private_ip_allocation_method": "Dynamic",
+  "subnet_id": "",
+  "private_ip_address": null
 }
 ```
 

--- a/infrastructure/modules/private-dns-zone-resolver/variables.tf
+++ b/infrastructure/modules/private-dns-zone-resolver/variables.tf
@@ -23,11 +23,23 @@ variable "inbound_endpoint_config" {
     name                         = string
     private_ip_allocation_method = string
     subnet_id                    = string
+    private_ip_address           = optional(string, null)
   })
   default = {
     name                         = ""
-    private_ip_allocation_method = ""
+    private_ip_allocation_method = "Dynamic"
     subnet_id                    = ""
+    private_ip_address           = null
+  }
+
+  validation {
+    condition     = contains(["Static", "Dynamic"], var.inbound_endpoint_config.private_ip_allocation_method)
+    error_message = "inbound_endpoint_config.private_ip_allocation_method must be either 'Static' or 'Dynamic'."
+  }
+
+  validation {
+    condition     = !(var.inbound_endpoint_config.private_ip_allocation_method == "Static" && var.inbound_endpoint_config.private_ip_address == null)
+    error_message = "inbound_endpoint_config.private_ip_address must be provided when private_ip_allocation_method is set to 'Static'."
   }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Change is adding a `private_ip_address` support to Private DNS Resolver inbound endpoint and extends the `inbound_endpoint_config` variable in the Private DNS Resolver module to support static IP address assignment for the inbound endpoint.

### Changes
- Added `private_ip_address` as an optional field to the `inbound_endpoint_config` object type
- Updated `azurerm_private_dns_resolver_inbound_endpoint` to conditionally pass `private_ip_address` to the `ip_configurations` block only when `private_ip_allocation_method` is set to `"Static"`

### Validations
Two validation rules have been added to the `inbound_endpoint_config` variable:

1. **Allowed values** - `private_ip_allocation_method` must be either `"Static"` or `"Dynamic"`. Any other value will fail at plan time.
2. **Conditional requirement** - `private_ip_address` must be provided when `private_ip_allocation_method` is set to `"Static"`. If omitted, Terraform will fail at plan time with a descriptive error message.

### Usage
No breaking changes. Existing callers using `"Dynamic"` allocation do not need to update their configuration - `private_ip_address` defaults to `null` and is silently ignored.

## Context

- Added `private_ip_address` as an optional field to the `inbound_endpoint_config` object type
- Updated `azurerm_private_dns_resolver_inbound_endpoint` to conditionally pass `private_ip_address` to the `ip_configurations` block only when `private_ip_allocation_method` is set to `"Static"`

### Validations
Two validation rules have been added to the `inbound_endpoint_config` variable:

1. **Allowed values** - `private_ip_allocation_method` must be either `"Static"` or `"Dynamic"`. Any other value will fail at plan time.
2. **Conditional requirement** - `private_ip_address` must be provided when `private_ip_allocation_method` is set to `"Static"`. If omitted, Terraform will fail at plan time with a descriptive error message.

### Usage
No breaking changes. Existing callers using `"Dynamic"` allocation do not need to update their configuration - `private_ip_address` defaults to `null` and is silently ignored.

```hcl
# Static allocation - private_ip_address required
inbound_endpoint_config = {
  name                         = "dns-resolver-inbound-prod"
  private_ip_allocation_method = "Static"
  subnet_id                    = azurerm_subnet.dns_inbound.id
  private_ip_address           = "10.100.7.4"
}
```

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
