### PR TITLE
fix: [DTOSS-13213] Function App retention period days repeatedly reported in Terraform Plan

### DIFF
--- a/infrastructure/modules/function-app/main.tf
+++ b/infrastructure/modules/function-app/main.tf
@@ -78,7 +78,10 @@ resource "azurerm_linux_function_app" "function_app" {
 
   # To prevent Terraform removing 'hidden-link:' tagging created automatically by AzureRM
   lifecycle {
-    ignore_changes = [tags]
+    ignore_changes = [
+      tags,
+      site_config[0].app_service_logs
+    ]
   }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

After some research, this currently does not have a fix. The value for `retention_period_days` in the state file is being set to zero after any change to the Function App resource (it does not change in the Azure itself). The only way to get rid of this in the plan is to add it to the `lifecycle.ignore` block. 

## Context

Currently it makes the already long Terraform Plan unreadable even if there are no real changes reported. 
It will be reverted once there is a fix for the bug in the AzureRM provider.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
